### PR TITLE
fix(dkg): harden story-kernel security and add tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 
 type GRPCConfig struct {
 	ListenAddr string `mapstructure:"listen_addr"`
+	// DebugMode enables development features such as gRPC reflection.
+	// Must remain false in production to avoid exposing service metadata.
+	DebugMode bool `mapstructure:"debug_mode"`
 }
 
 type LightClientConfig struct {

--- a/server/server.go
+++ b/server/server.go
@@ -35,8 +35,12 @@ func Serve(cfg *config.Config) (*grpc.Server, chan error) {
 	// Register story-kernel service server
 	registerAllServices(svr, cfg, queryClient)
 
-	// TODO: temporarily add reflection for test. Need to remove this in production
-	reflection.Register(svr)
+	// Only enable gRPC reflection in debug mode for development/testing.
+	// Reflection exposes service metadata and must not be enabled in production.
+	if cfg.GRPC.DebugMode {
+		log.Warn("gRPC reflection is enabled (debug mode). Do NOT use in production.")
+		reflection.Register(svr)
+	}
 
 	go runServer(cfg, svr, errCh)
 

--- a/service/crypto_wipe.go
+++ b/service/crypto_wipe.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+)
+
+// zeroBytes overwrites the given byte slice with zeros.
+// This is used to minimize the window during which sensitive
+// key material resides in memory after it is no longer needed.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// zeroPrivateKey overwrites an ECDSA private key's secret scalar (D)
+// with zero. The caller should defer this immediately after loading
+// the key.
+func zeroPrivateKey(key *ecdsa.PrivateKey) {
+	if key == nil || key.D == nil {
+		return
+	}
+	key.D.SetInt64(0)
+	// Also clear the internal byte representation if the big.Int
+	// has allocated space.
+	key.D = new(big.Int)
+}

--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -155,6 +155,8 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 
 		return nil, status.Errorf(codes.Internal, "failed to load sealed secp256k1 key")
 	}
+	// Zero out the private key after use to minimize exposure in memory.
+	defer zeroPrivateKey(priv)
 
 	signature, err := ecrypto.Sign(respHash, priv)
 	if err != nil {

--- a/service/dkg_generate_deals.go
+++ b/service/dkg_generate_deals.go
@@ -136,7 +136,7 @@ func (s *DKGServer) CachePID(codeCommitmentHex string, round uint32, regs []*pb.
 	}
 
 	if ownPID == 0 {
-		return errors.Wrap(err, "own public key not found in registrations")
+		return errors.New("own public key not found in registrations")
 	}
 
 	s.PIDCache.Set(round, ownPID)

--- a/service/dkg_partial_decrypt.go
+++ b/service/dkg_partial_decrypt.go
@@ -30,6 +30,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	// sec1UncompressedPrefix is the SEC1 standard prefix byte for uncompressed elliptic curve points.
+	sec1UncompressedPrefix = 0x04
+	// tdh2Edwards25519CurveID is the cb-mpc TDH2 custom curve identifier for Edwards25519.
+	tdh2Edwards25519CurveID = 0x3f
+)
+
 // PartialDecryptTDH2 performs TDH2 partial decryption using the sealed Kyber private share.
 // TODO: TEE should verify if the request transaction was indeed submitted to the canonical chain and the unique ID
 // and round match to prevent any leakage of data by off-chain collusion.
@@ -91,6 +98,8 @@ func (s *DKGServer) PartialDecryptTDH2(ctx context.Context, req *pb.PartialDecry
 
 		return nil, status.Errorf(codes.Internal, "failed to marshal private share")
 	}
+	// Zero out the private share bytes after use to minimize exposure in memory.
+	defer zeroBytes(privShare.Bytes)
 
 	pubKey, err := buildTDH2PublicKey(req.GetGlobalPubKey())
 	if err != nil {
@@ -196,6 +205,8 @@ func (s *DKGServer) signPartialDecryptResponse(codeCommitment []byte, round uint
 	if err != nil {
 		return nil, fmt.Errorf("failed to load sealed secp256k1 key: %w", err)
 	}
+	// Zero out the private key after use to minimize exposure in memory.
+	defer zeroPrivateKey(priv)
 
 	signature, err := ecrypto.Sign(respHash, priv)
 	if err != nil {
@@ -218,7 +229,7 @@ func bytes2PrivateShare(scalar kyber.Scalar) (*mpc.TDH2PrivateShare, error) {
 }
 
 func buildTDH2PublicKey(dkgPubKey []byte) (*mpc.TDH2PublicKey, error) {
-	tdhPointBytes := append([]byte{0x04, 0x3f}, dkgPubKey...)
+	tdhPointBytes := append([]byte{sec1UncompressedPrefix, tdh2Edwards25519CurveID}, dkgPubKey...)
 	pubKey, err := mpc.TDH2PublicKeyFromPoint(tdhPointBytes)
 	if err != nil {
 		return nil, fmt.Errorf("build TDH2 public key: %w", err)
@@ -250,6 +261,7 @@ func encryptPartialToRequester(requesterPubKey []byte, partial []byte) ([]byte, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate ephemeral key: %w", err)
 	}
+	defer zeroPrivateKey(ephemeral)
 
 	ephemeralECIES := ecies.ImportECDSA(ephemeral)
 	requesterECIES := ecies.ImportECDSAPublic(requesterECDSA)
@@ -257,12 +269,14 @@ func encryptPartialToRequester(requesterPubKey []byte, partial []byte) ([]byte, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to derive shared secret: %w", err)
 	}
+	defer zeroBytes(sharedBytes)
 
 	h := hkdf.New(sha256.New, sharedBytes, nil, []byte("dkg-tdh2-partial"))
 	aesKey := make([]byte, 32)
 	if _, err := io.ReadFull(h, aesKey); err != nil {
 		return nil, nil, fmt.Errorf("failed to derive key: %w", err)
 	}
+	defer zeroBytes(aesKey)
 
 	block, err := aes.NewCipher(aesKey)
 	if err != nil {

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -103,9 +103,9 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 			if j != nil {
 				justification, err := types.ConvertToJustificationProto(j)
 				if err != nil {
+					// Log only the index to avoid leaking sensitive data (e.g., SecShare in PlainDeal).
 					log.WithFields(log.Fields{
-						"index":         j.Index,
-						"justification": j.Justification,
+						"justification_index": j.Index,
 					}).Errorf("failed to convert to justification proto: %v", err)
 
 					return nil, status.Errorf(codes.Internal, "failed to convert to justification proto")

--- a/service/utils_test.go
+++ b/service/utils_test.go
@@ -385,6 +385,78 @@ func TestEncodingConsistency(t *testing.T) {
 	})
 }
 
+func TestReverseBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "empty slice",
+			input:    []byte{},
+			expected: []byte{},
+		},
+		{
+			name:     "single byte",
+			input:    []byte{0xAB},
+			expected: []byte{0xAB},
+		},
+		{
+			name:     "even length",
+			input:    []byte{0x01, 0x02, 0x03, 0x04},
+			expected: []byte{0x04, 0x03, 0x02, 0x01},
+		},
+		{
+			name:     "odd length",
+			input:    []byte{0x01, 0x02, 0x03},
+			expected: []byte{0x03, 0x02, 0x01},
+		},
+		{
+			name:     "all zeros",
+			input:    []byte{0x00, 0x00, 0x00, 0x00},
+			expected: []byte{0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:     "all 0xFF",
+			input:    []byte{0xFF, 0xFF, 0xFF, 0xFF},
+			expected: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			name:     "two bytes",
+			input:    []byte{0xDE, 0xAD},
+			expected: []byte{0xAD, 0xDE},
+		},
+		{
+			name:     "palindrome",
+			input:    []byte{0xAB, 0xCD, 0xAB},
+			expected: []byte{0xAB, 0xCD, 0xAB},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reverseBytes(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReverseBytesDoesNotMutateInput(t *testing.T) {
+	original := []byte{0x01, 0x02, 0x03}
+	inputCopy := make([]byte, len(original))
+	copy(inputCopy, original)
+
+	_ = reverseBytes(original)
+
+	assert.Equal(t, inputCopy, original, "reverseBytes must not mutate the input slice")
+}
+
+func TestReverseBytesNil(t *testing.T) {
+	result := reverseBytes(nil)
+	assert.NotNil(t, result, "reverseBytes(nil) should return a non-nil empty slice")
+	assert.Len(t, result, 0)
+}
+
 // Benchmark tests
 func BenchmarkCalculateReportData(b *testing.B) {
 	validatorAddr := "0x1234567890123456789012345678901234567890"

--- a/store/dkg_state.go
+++ b/store/dkg_state.go
@@ -38,6 +38,7 @@ type dkgStateDisk struct {
 	Deals          []dkg.Deal          `json:"deals"`
 	Responses      []dkg.Response      `json:"responses"`
 	Justifications []justificationDisk `json:"justifications,omitempty"`
+	FromRound      uint32              `json:"from_round,omitempty"`
 }
 
 // justificationDisk is the JSON-serializable representation of dkg.Justification.
@@ -234,6 +235,7 @@ func (s *DKGStore) toDisk(st *DKGState) (*dkgStateDisk, error) {
 		Deals:          st.Deals,
 		Responses:      st.Responses,
 		Justifications: justDisk,
+		FromRound:      st.FromRound,
 		PubKeysBase64:  make([]string, len(st.PubKeys)),
 	}
 
@@ -259,6 +261,7 @@ func (s *DKGStore) fromDisk(d *dkgStateDisk) (*DKGState, error) {
 		Deals:          d.Deals,
 		Responses:      d.Responses,
 		Justifications: justs,
+		FromRound:      d.FromRound,
 		PubKeys:        make([]kyber.Point, len(d.PubKeysBase64)),
 	}
 

--- a/store/dkg_state_test.go
+++ b/store/dkg_state_test.go
@@ -145,6 +145,74 @@ func TestEmptyJustificationsOmitted(t *testing.T) {
 	require.Empty(t, restored.Justifications)
 }
 
+// TestFromRoundRoundTrip verifies that the FromRound field survives
+// serialization and deserialization through toDisk/fromDisk.
+func TestFromRoundRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := newTestDKGStore(t)
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	pub := suite.Point().Mul(suite.Scalar().Pick(suite.RandomStream()), nil)
+	original := &DKGState{
+		PubKeys:   []kyber.Point{pub},
+		Threshold: 2,
+		FromRound: 5,
+	}
+
+	disk, err := store.toDisk(original)
+	require.NoError(t, err)
+	require.Equal(t, uint32(5), disk.FromRound)
+
+	restored, err := store.fromDisk(disk)
+	require.NoError(t, err)
+	require.Equal(t, uint32(5), restored.FromRound)
+}
+
+// TestFromRoundPersistence verifies that FromRound is persisted to disk
+// and can be loaded back correctly.
+func TestFromRoundPersistence(t *testing.T) {
+	t.Parallel()
+	store := newTestDKGStore(t)
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	codeCommitment := "fromround1234567890"
+	round := uint32(3)
+
+	ensureStateDir(t, store, codeCommitment, round)
+
+	pub := suite.Point().Mul(suite.Scalar().Pick(suite.RandomStream()), nil)
+	require.NoError(t, store.SaveDKGState(&DKGState{
+		PubKeys:   []kyber.Point{pub},
+		Threshold: 2,
+		FromRound: 2,
+	}, codeCommitment, round))
+
+	st, err := store.LoadDKGState(codeCommitment, round)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), st.FromRound)
+}
+
+// TestFromRoundZeroOmitted verifies that FromRound == 0 is handled correctly
+// (omitempty means it won't appear in JSON, but should deserialize to 0).
+func TestFromRoundZeroOmitted(t *testing.T) {
+	t.Parallel()
+	store := newTestDKGStore(t)
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	pub := suite.Point().Mul(suite.Scalar().Pick(suite.RandomStream()), nil)
+	original := &DKGState{
+		PubKeys:   []kyber.Point{pub},
+		Threshold: 2,
+		FromRound: 0,
+	}
+
+	disk, err := store.toDisk(original)
+	require.NoError(t, err)
+
+	restored, err := store.fromDisk(disk)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), restored.FromRound)
+}
+
 // TestBackwardCompatibility verifies that loading a state file without
 // justifications field still works (backward compatibility with existing state files).
 func TestBackwardCompatibility(t *testing.T) {


### PR DESCRIPTION
## Summary

  - Gate gRPC reflection behind `DebugMode` config flag to prevent service metadata exposure in production
  - Add cryptographic memory wiping: zero out private keys, shared secrets, ephemeral keys, and AES keys after use via `zeroBytes` and `zeroPrivateKey` helpers
  - Remove sensitive justification data (e.g., `SecShare` in `PlainDeal`) from log output, logging only the index
  - Fix `errors.Wrap(nil, ...)` misuse in `CachePID` — replace with `errors.New`
  - Add named constants for TDH2 magic bytes (`sec1UncompressedPrefix`, `tdh2Edwards25519CurveID`)
  - Persist `FromRound` field in DKG state serialization for resharing provenance tracking
  - Add `reverseBytes` edge case tests (nil, empty, single byte, palindrome)
  - Add `FromRound` round-trip, persistence, and zero-value serialization tests