### PR TITLE
fix: return InvalidArgument instead of Internal for client input errors

### DIFF
--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -35,7 +35,7 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 	if err := enclave.ValidateCodeCommitment(req.GetCodeCommitment()); err != nil {
 		log.Errorf("failed to validate code commitment: %v", err)
 
-		return nil, status.Errorf(codes.Internal, "failed to validate code commitment")
+		return nil, status.Errorf(codes.InvalidArgument, "failed to validate code commitment")
 	}
 
 	rc, err := s.GetOrLoadRoundContext(codeCommitmentHex, req.GetRound())

--- a/service/dkg_process_deals_test.go
+++ b/service/dkg_process_deals_test.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+)
+
+func TestValidateProcessDealsRequest_MissingRound(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessDealsRequest{
+		Round:          0,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Deals:          []*pb.Deal{{Index: 1}},
+	}
+
+	err := validateProcessDealsRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "round should be greater than 0")
+}
+
+func TestValidateProcessDealsRequest_MissingCodeCommitment(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessDealsRequest{
+		Round:          1,
+		CodeCommitment: nil,
+		Deals:          []*pb.Deal{{Index: 1}},
+	}
+
+	err := validateProcessDealsRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code commitment is required but missing")
+}
+
+func TestValidateProcessDealsRequest_EmptyDeals(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessDealsRequest{
+		Round:          1,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Deals:          nil,
+	}
+
+	err := validateProcessDealsRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty deals to process")
+}
+
+func TestValidateProcessDealsRequest_Valid(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessDealsRequest{
+		Round:          1,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Deals:          []*pb.Deal{{Index: 1}},
+	}
+
+	err := validateProcessDealsRequest(req)
+	require.NoError(t, err)
+}
+
+func TestValidateProcessDealsRequest_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	validCC := []byte("32-byte-code-commitment-padding!!")
+	validDeals := []*pb.Deal{{Index: 1}}
+
+	tests := []struct {
+		name           string
+		round          uint32
+		codeCommitment []byte
+		deals          []*pb.Deal
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "all fields valid",
+			round:          1,
+			codeCommitment: validCC,
+			deals:          validDeals,
+			wantErr:        false,
+		},
+		{
+			name:           "round is zero",
+			round:          0,
+			codeCommitment: validCC,
+			deals:          validDeals,
+			wantErr:        true,
+			errContains:    "round should be greater than 0",
+		},
+		{
+			name:           "code commitment is nil",
+			round:          1,
+			codeCommitment: nil,
+			deals:          validDeals,
+			wantErr:        true,
+			errContains:    "code commitment is required but missing",
+		},
+		{
+			name:           "code commitment is empty",
+			round:          1,
+			codeCommitment: []byte{},
+			deals:          validDeals,
+			wantErr:        true,
+			errContains:    "code commitment is required but missing",
+		},
+		{
+			name:           "deals is nil",
+			round:          1,
+			codeCommitment: validCC,
+			deals:          nil,
+			wantErr:        true,
+			errContains:    "empty deals to process",
+		},
+		{
+			name:           "deals is empty slice",
+			round:          1,
+			codeCommitment: validCC,
+			deals:          []*pb.Deal{},
+			wantErr:        true,
+			errContains:    "empty deals to process",
+		},
+		{
+			name:           "max round value",
+			round:          ^uint32(0),
+			codeCommitment: validCC,
+			deals:          validDeals,
+			wantErr:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := &pb.ProcessDealsRequest{
+				Round:          tc.round,
+				CodeCommitment: tc.codeCommitment,
+				Deals:          tc.deals,
+			}
+
+			err := validateProcessDealsRequest(req)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -27,14 +27,14 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 			"num_responses":   len(req.GetResponses()),
 		}).Errorf("invalid request: %v", err)
 
-		return nil, status.Errorf(codes.Internal, "invalid request")
+		return nil, status.Errorf(codes.InvalidArgument, "invalid request")
 	}
 
 	// Validate code commitment
 	if err := enclave.ValidateCodeCommitment(req.GetCodeCommitment()); err != nil {
 		log.Errorf("failed to validate code commitment: %v", err)
 
-		return nil, status.Errorf(codes.Internal, "failed to validate code commitment")
+		return nil, status.Errorf(codes.InvalidArgument, "failed to validate code commitment")
 	}
 
 	rc, err := s.GetOrLoadRoundContext(codeCommitmentHex, req.GetRound())

--- a/service/dkg_process_responses_test.go
+++ b/service/dkg_process_responses_test.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+)
+
+func TestValidateProcessResponsesRequest_MissingRound(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessResponsesRequest{
+		Round:          0,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Responses:      []*pb.Response{{Index: 1, VssResponse: &pb.VSSResponse{}}},
+	}
+
+	err := validateProcessResponsesRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "round should be greater than 0")
+}
+
+func TestValidateProcessResponsesRequest_MissingCodeCommitment(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessResponsesRequest{
+		Round:          1,
+		CodeCommitment: nil,
+		Responses:      []*pb.Response{{Index: 1, VssResponse: &pb.VSSResponse{}}},
+	}
+
+	err := validateProcessResponsesRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code commitment is required but missing")
+}
+
+func TestValidateProcessResponsesRequest_EmptyResponses(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessResponsesRequest{
+		Round:          1,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Responses:      nil,
+	}
+
+	err := validateProcessResponsesRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty responses to process")
+}
+
+func TestValidateProcessResponsesRequest_Valid(t *testing.T) {
+	t.Parallel()
+
+	req := &pb.ProcessResponsesRequest{
+		Round:          1,
+		CodeCommitment: []byte("32-byte-code-commitment-padding!!"),
+		Responses:      []*pb.Response{{Index: 1, VssResponse: &pb.VSSResponse{}}},
+	}
+
+	err := validateProcessResponsesRequest(req)
+	require.NoError(t, err)
+}
+
+func TestValidateProcessResponsesRequest_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	validCC := []byte("32-byte-code-commitment-padding!!")
+	validResps := []*pb.Response{{Index: 1, VssResponse: &pb.VSSResponse{}}}
+
+	tests := []struct {
+		name           string
+		round          uint32
+		codeCommitment []byte
+		responses      []*pb.Response
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "all fields valid",
+			round:          1,
+			codeCommitment: validCC,
+			responses:      validResps,
+			wantErr:        false,
+		},
+		{
+			name:           "round is zero",
+			round:          0,
+			codeCommitment: validCC,
+			responses:      validResps,
+			wantErr:        true,
+			errContains:    "round should be greater than 0",
+		},
+		{
+			name:           "code commitment is nil",
+			round:          1,
+			codeCommitment: nil,
+			responses:      validResps,
+			wantErr:        true,
+			errContains:    "code commitment is required but missing",
+		},
+		{
+			name:           "code commitment is empty",
+			round:          1,
+			codeCommitment: []byte{},
+			responses:      validResps,
+			wantErr:        true,
+			errContains:    "code commitment is required but missing",
+		},
+		{
+			name:           "responses is nil",
+			round:          1,
+			codeCommitment: validCC,
+			responses:      nil,
+			wantErr:        true,
+			errContains:    "empty responses to process",
+		},
+		{
+			name:           "responses is empty slice",
+			round:          1,
+			codeCommitment: validCC,
+			responses:      []*pb.Response{},
+			wantErr:        true,
+			errContains:    "empty responses to process",
+		},
+		{
+			name:           "max round value",
+			round:          ^uint32(0),
+			codeCommitment: validCC,
+			responses:      validResps,
+			wantErr:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := &pb.ProcessResponsesRequest{
+				Round:          tc.round,
+				CodeCommitment: tc.codeCommitment,
+				Responses:      tc.responses,
+			}
+
+			err := validateProcessResponsesRequest(req)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Summary**

  - Replace `codes.Internal` with `codes.InvalidArgument` for client input validation errors in ProcessResponses and ProcessDeals
  - Aligns error codes with the other five RPC handlers (GenerateAndSealKey, GenerateDeals, FinalizeDKG, ProcessJustification, PartialDecryptTDH2) that already use `codes.InvalidArgument` for request validation failures
  - Three locations fixed: `dkg_process_responses.go` lines 30 and 37, `dkg_process_deals.go` line 38

issue: #21 