### PR TITLE
ci: add Codecov coverage reporting and badge

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    project:
+      default:
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+
+ignore:
+  - "*.md"
+  - "cmd/"
+  - "server/"
+  - "scripts/"
+  - "**/*.pb.go"
+  - "types/pb/"

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   unit_tests:
@@ -44,5 +47,15 @@ jobs:
       - name: Verify OpenSSL installation
         run: ls -la /usr/local/lib64/libcrypto.a
 
-      - name: Run tests (includes cb-mpc setup)
-        run: make test
+      - name: Run tests with coverage
+        run: make test-cover
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.txt
+          flags: unittests
+          name: go-tests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ proto-gen:
 test: setup-cbmpc
 	CGO_LDFLAGS_ALLOW=".*" ./scripts/go_with_cpp.sh $(CBMPC_PATH) go test -v ./...
 
+test-cover: setup-cbmpc
+	CGO_LDFLAGS_ALLOW=".*" ./scripts/go_with_cpp.sh $(CBMPC_PATH) go test -coverprofile=coverage.txt -timeout=5m -race ./...
+
 # Install dependencies for Ubuntu (run with sudo)
 setup-deps:
 	@echo "Installing build dependencies..."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Story Kernel
 
+[![Website](https://img.shields.io/badge/story.foundation-4B3263?style=flat&logo=google-chrome&logoColor=white)](https://www.story.foundation)
+[![X](https://img.shields.io/badge/@StoryProtocol-000000?style=flat&logo=x&logoColor=white)](https://x.com/StoryProtocol)
+[![codecov](https://codecov.io/gh/piplabs/story-kernel/branch/main/graph/badge.svg)](https://codecov.io/gh/piplabs/story-kernel)
+
 > ⚠️ **WARNING**: This software has not been audited and is not production-ready. Use at your own risk.
 
 Story Kernel is a Trusted Execution Environment (TEE) client for Story Protocol's Distributed Key Generation (DKG)


### PR DESCRIPTION
## Summary

  Add Codecov integration for test coverage reporting.

  - Configure `.codecov.yml` with 1% threshold, ignoring generated code (`*.pb.go`), `cmd/`, `server/`, `scripts/`
  - Update `gotest.yml` to generate coverage profile and upload via `codecov-action@v5`
  - Add Website, X, and Codecov badges to README

  ## Setup

  Requires `CODECOV_TOKEN` secret in GitHub repo settings (Settings → Secrets → Actions).