### PR TITLE
fix(dkg): return empty success instead of error for duplicate deals

### DIFF
--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -88,10 +88,21 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		deals = append(deals, *deal)
 	}
 
-	// Reject the request if every submitted deal failed processing.
+	// If no deals were successfully processed (e.g., all duplicates), return
+	// an empty success response instead of an error. This is consistent with
+	// ProcessResponses and ProcessJustifications, and prevents the CL from
+	// caching duplicate deals for infinite retry.
 	if len(deals) == 0 {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"all %d submitted deals were rejected", len(req.GetDeals()))
+		log.WithFields(log.Fields{
+			"round":           req.GetRound(),
+			"code_commitment": codeCommitmentHex,
+			"submitted":       len(req.GetDeals()),
+		}).Warn("all submitted deals were skipped (e.g., duplicates)")
+
+		return &pb.ProcessDealsResponse{
+			CodeCommitment: req.GetCodeCommitment(),
+			Round:          req.GetRound(),
+		}, nil
 	}
 
 	if err := s.DKGStore.AddDeals(codeCommitmentHex, req.GetRound(), deals); err != nil {
@@ -100,7 +111,12 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		return nil, status.Errorf(codes.Internal, "failed to add deals to the DKG state")
 	}
 
-	log.Info("All deals have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"submitted":       len(req.GetDeals()),
+		"processed":       len(deals),
+	}).Info("Deals processed")
 
 	return &pb.ProcessDealsResponse{
 		CodeCommitment: req.GetCodeCommitment(),

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -111,6 +111,9 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 			}
 		}
 
+		// Always persist justifications for recovery replay, even if some DKG
+		// instances rejected them. During resharing, a justification may apply
+		// to only one of the DKG instances (prev or next).
 		processed = append(processed, *justification)
 
 		log.WithFields(log.Fields{
@@ -118,6 +121,14 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 			"code_commitment": codeCommitmentHex,
 			"dealer_index":    justification.Index,
 		}).Info("Justification processed successfully, DKG state restored for the deal")
+	}
+
+	if len(processed) == 0 {
+		log.WithFields(log.Fields{
+			"round":           req.GetRound(),
+			"code_commitment": codeCommitmentHex,
+			"submitted":       len(req.GetJustifications()),
+		}).Warn("all submitted justifications were skipped")
 	}
 
 	// Persist successfully processed justifications for recovery replay

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -129,7 +129,12 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 		}
 	}
 
-	log.Info("All justifications have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"submitted":       len(req.GetJustifications()),
+		"processed":       len(processed),
+	}).Info("Justifications processed")
 
 	return &pb.ProcessJustificationResponse{}, nil
 }

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -124,7 +124,12 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 		return nil, status.Errorf(codes.Internal, "failed to add responses to the DKG state")
 	}
 
-	log.Info("All responses have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"submitted":       len(req.GetResponses()),
+		"processed":       len(resps),
+	}).Info("Responses processed")
 
 	return &pb.ProcessResponsesResponse{
 		Justifications: justifications,


### PR DESCRIPTION
## Summary

  - Return empty success instead of error when all submitted deals are duplicates in `ProcessDeals`
  - Add all-skip warn log for `ProcessJustifications`, consistent with `ProcessDeals`
  - Add structured processing count logs (`submitted`/`processed`) to all three DKG processing functions

  ## Problem

  Due to CometBFT's vote extension lifecycle (`ExtendVote` runs before `FinalizeBlock`), the same deals can arrive in two consecutive blocks. When the kernel receives duplicate deals, kyber's `DistKeyGenerator.ProcessDeal` rejects all of them. Previously, `ProcessDeals` returned `InvalidArgument` error in this case, which caused the CL to cache the deals for retry — creating an infinite retry loop that never resolves.

  `ProcessResponses` and `ProcessJustifications` already handled this gracefully by skipping failed items and returning success. Only `ProcessDeals` returned an error.

  ## Fix

  When all submitted deals are rejected (e.g., duplicates), return an empty success response with no responses instead of an error. The CL receives an empty `ProcessDealsResponse` and moves on without caching.