### PR TITLE
feat: add version command to print build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ BUILD_FLAGS := -tags "$(build_tags)"
 OUT_DIR = ./build
 BIN_NAME = story-kernel
 
+# Build info injected via -ldflags -X
+GIT_COMMIT := $(shell git rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+GIT_TIMESTAMP := $(shell git log -1 --format=%cI 2>/dev/null || echo "unknown")
+BUILDINFO_PKG := github.com/piplabs/story-kernel/buildinfo
+BUILDINFO_FLAGS := -X $(BUILDINFO_PKG).GitCommit=$(GIT_COMMIT) -X $(BUILDINFO_PKG).GitTimestamp=$(GIT_TIMESTAMP)
+
 # cb-mpc settings
 CBMPC_DIR = .cbmpc
 CBMPC_REPO = https://github.com/piplabs/cb-mpc-fork.git
@@ -33,11 +39,11 @@ setup-cbmpc:
 
 # Simple build without cb-mpc (requires pre-built libcbmpc.a)
 build:
-	$(GO) build -mod=readonly $(BUILD_FLAGS) -o $(OUT_DIR)/$(BIN_NAME) ./
+	$(GO) build -mod=readonly $(BUILD_FLAGS) -ldflags="$(BUILDINFO_FLAGS)" -o $(OUT_DIR)/$(BIN_NAME) ./
 
 # Build with cb-mpc C++ library (auto-builds cb-mpc if needed)
 build-with-cpp: setup-cbmpc
-	CGO_LDFLAGS_ALLOW=".*" ./scripts/go_with_cpp.sh $(CBMPC_PATH) $(GO) build -mod=readonly $(BUILD_FLAGS) -ldflags="-extldflags=-Wl,-w" -o $(OUT_DIR)/$(BIN_NAME) ./
+	CGO_LDFLAGS_ALLOW=".*" ./scripts/go_with_cpp.sh $(CBMPC_PATH) $(GO) build -mod=readonly $(BUILD_FLAGS) -ldflags="-buildid= $(BUILDINFO_FLAGS) -extldflags=-Wl,-w" -o $(OUT_DIR)/$(BIN_NAME) ./
 
 # Run standard (non-SGX) binary
 run:

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -1,0 +1,59 @@
+package buildinfo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	VersionMajor = 0          // Major version component of the current release
+	VersionMinor = 1          // Minor version component of the current release
+	VersionPatch = 1          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
+)
+
+// GitCommit and GitTimestamp are set via -ldflags at build time.
+// The SGX reproducible build uses -buildvcs=false, so runtime/debug
+// build settings are unavailable. These variables are the fallback.
+var (
+	GitCommit    = "unknown"
+	GitTimestamp = "unknown"
+)
+
+// Version returns the semantic version string.
+func Version() string {
+	return fmt.Sprintf("v%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+}
+
+// VersionWithMeta returns the version string including metadata.
+func VersionWithMeta() string {
+	v := Version()
+	if VersionMeta != "" {
+		v += "-" + VersionMeta
+	}
+
+	return v
+}
+
+// NewVersionCmd returns a cobra command that prints build info.
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version information of this binary",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			var sb strings.Builder
+
+			_, _ = sb.WriteString("Version       " + VersionWithMeta())
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Commit    " + GitCommit)
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Timestamp " + GitTimestamp)
+			_, _ = sb.WriteString("\n")
+
+			cmd.Print(sb.String())
+		},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/piplabs/story-kernel/buildinfo"
 	"github.com/piplabs/story-kernel/config"
 )
 
@@ -37,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(
 		initCmd,
 		startCmd,
+		buildinfo.NewVersionCmd(),
 	)
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/piplabs/story-kernel/buildinfo"
 	"github.com/piplabs/story-kernel/server"
 )
 
@@ -15,6 +16,11 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the story-kernel gRPC server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		log.WithFields(log.Fields{
+			"version": buildinfo.VersionWithMeta(),
+			"commit":  buildinfo.GitCommit,
+		}).Info("Starting story-kernel")
+
 		cfg, err := loadConfigFromHome(cmd)
 		if err != nil {
 			return err

--- a/scripts/go_with_cpp.sh
+++ b/scripts/go_with_cpp.sh
@@ -137,7 +137,7 @@ cd "${REPO_ROOT}"
 # Inject reproducible build flags for SGX code commitment determinism
 # Without these, builds on different machines produce different binaries
 if [[ "${1:-}" == *go && "${2:-}" == "build" ]]; then
-  REPRO_FLAGS=(-trimpath -buildvcs=false -ldflags="-buildid=")
+  REPRO_FLAGS=(-trimpath -buildvcs=false)
   echo "[go_with_cpp] Adding reproducible build flags: ${REPRO_FLAGS[*]}"
   set -- "$1" "$2" "${REPRO_FLAGS[@]}" "${@:3}"
 fi


### PR DESCRIPTION
  ## Summary

  Add `story-kernel version` command that prints version, git commit hash, and git timestamp — consistent with story consensus client's `story version` command. Also logs version info on `story-kernel start`.

  ## Changes

  - **`buildinfo/buildinfo.go`**: Version constants (`v0.1.1-unstable`), `GitCommit`/`GitTimestamp` variables injected via `-ldflags -X` at build time
  - **`cmd/root.go`**: Register `version` subcommand
  - **`cmd/start.go`**: Log version and commit on startup
  - **`Makefile`**: Inject git commit hash and timestamp via `-ldflags -X` in both `build` and `build-with-cpp` targets
  - **`scripts/go_with_cpp.sh`**: Remove `-ldflags` from reproducible build flags (now handled by Makefile to avoid flag conflicts)

  ## Why `-ldflags -X` instead of `runtime/debug`

  The SGX reproducible build uses `-buildvcs=false` (required for deterministic MRENCLAVE), which strips `vcs.*` info from `runtime/debug.ReadBuildInfo()`. Git info is instead injected at build time via Makefile's `-ldflags -X`.