### PR TITLE
fix: block config.toml fallback after DKG registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,40 +375,28 @@ The light client's trusted state is sealed with SGX, ensuring confidentiality an
 
 On startup, the kernel determines its light client initialization strategy as follows:
 
-| Sealed DB state | DKG key shares | Action |
-|-----------------|---------------|--------|
-| Valid | Any | Resume from sealed DB |
-| Expired / Invalid | None | Fall back to `config.toml` (pre-registration) |
-| Expired / Invalid | Exist | **Refuse to start** |
-| Missing | None | Initialize from `config.toml` (first boot) |
-| Missing | Exist | **Refuse to start** |
+| Sealed DB state | Action |
+|-----------------|--------|
+| Valid | Resume from sealed DB, use existing session nonce |
+| Expired / Invalid | Re-initialize from `config.toml`, generate new session nonce |
+| Missing | Initialize from `config.toml` (first boot), generate new session nonce |
 
-Once DKG key shares (`dist_key_share.sealed`) exist, the kernel will only resume from
-its sealed light client DB. It will not fall back to `config.toml` for light client
-initialization because `config.toml` is not sealed and could be modified from outside the
-enclave.
+A session nonce (32-byte random value) is stored in the sealed light client DB and
+embedded in all sealed DKG files via the `NonceBindingSealer`. When the light client is
+re-initialized from `config.toml` (due to expiration, corruption, or DB deletion), a new
+nonce is generated. Any pre-existing sealed DKG files created under the prior nonce will
+fail verification at use time and must be re-created through a new DKG round.
 
-### Recovery procedure
+### Recovery after light client state loss
 
-If the kernel refuses to start because the sealed light client state is missing or expired
-while DKG key shares exist, the operator must:
-
-1. Remove the DKG state directory:
-   ```bash
-   rm -rf /opt/story-kernel/dkg_state/
-   ```
-2. Restart the kernel (it will initialize the light client from `config.toml`)
-3. Re-register for the current DKG round
-
-> **Note:** This recovery procedure removes all past round `dist_key_share` files.
-> The validator will no longer be able to participate in TDH2 partial decryption for
-> previous rounds. This is an accepted tradeoff — allowing `config.toml` to re-initialize
-> the light client while key shares exist would break the chain identity continuity
-> guarantee that the sealed light client DB provides.
+If the light client state is lost (DB deleted or expired beyond the trusted period),
+the kernel will re-initialize from `config.toml` with a new session nonce. Existing
+sealed DKG files will no longer be usable due to nonce mismatch. The operator must
+re-register for the current DKG round to resume participation.
 
 ### Preventing light client state loss
 
-To avoid the recovery procedure above, operators should:
+To avoid the need for re-registration, operators should:
 
 - **Keep the kernel running.** The light client state expires after the trusted period
   (~2 weeks of inactivity). Restarting within this window resumes normally from the sealed DB.
@@ -426,7 +414,7 @@ To avoid the recovery procedure above, operators should:
 - **File Access**: The Gramine manifest restricts enclave file access to `/opt/story-kernel/` only. `/etc/ssl/certs/` is in `allowed_files` (not `trusted_files`) because CA certificate bundles differ across machines and would break MRENCLAVE reproducibility.
 - **Fixed Data Path**: The data directory is `/opt/story-kernel/` (not `~/.story-kernel/`) to ensure all validators produce the same MRENCLAVE regardless of OS user. See the [Data Directory](#data-directory) section for details.
 - **MRENCLAVE Reproducibility**: The entire Gramine manifest — every byte — is measured into the code commitment. All values that could vary (log level, binary name) are hardcoded in the manifest. See [Software Requirements](#software-requirements) for the exact versions required.
-- **Light Client Chain Identity**: After DKG registration, the kernel refuses to initialize the light client from `config.toml`. See the [Light Client Recovery](#light-client-recovery) section for the rationale and recovery procedure.
+- **Light Client Session Binding**: All sealed DKG files are bound to the light client DB session via a nonce. When the light client is re-initialized from `config.toml`, a new nonce is generated and prior sealed files are invalidated. See the [Light Client Recovery](#light-client-recovery) section for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,58 @@ The service exposes a gRPC API with the following methods:
 | `FinalizeDKG` | Finalize DKG and produce distributed key share |
 | `PartialDecryptTDH2` | Perform TDH2 partial decryption |
 
+## Light Client Recovery
+
+Story Kernel uses a CometBFT light client backed by a sealed LevelDB to verify on-chain state.
+The light client's trusted state is sealed with SGX, ensuring confidentiality and integrity.
+`config.toml`, however, resides in `allowed_files` and is not sealed.
+
+### Initialization strategy
+
+On startup, the kernel determines its light client initialization strategy as follows:
+
+| Sealed DB state | DKG key shares | Action |
+|-----------------|---------------|--------|
+| Valid | Any | Resume from sealed DB |
+| Expired / Invalid | None | Fall back to `config.toml` (pre-registration) |
+| Expired / Invalid | Exist | **Refuse to start** |
+| Missing | None | Initialize from `config.toml` (first boot) |
+| Missing | Exist | **Refuse to start** |
+
+Once DKG key shares (`dist_key_share.sealed`) exist, the kernel will only resume from
+its sealed light client DB. It will not fall back to `config.toml` for light client
+initialization because `config.toml` is not sealed and could be modified from outside the
+enclave.
+
+### Recovery procedure
+
+If the kernel refuses to start because the sealed light client state is missing or expired
+while DKG key shares exist, the operator must:
+
+1. Remove the DKG state directory:
+   ```bash
+   rm -rf /opt/story-kernel/dkg_state/
+   ```
+2. Restart the kernel (it will initialize the light client from `config.toml`)
+3. Re-register for the current DKG round
+
+> **Note:** This recovery procedure removes all past round `dist_key_share` files.
+> The validator will no longer be able to participate in TDH2 partial decryption for
+> previous rounds. This is an accepted tradeoff — allowing `config.toml` to re-initialize
+> the light client while key shares exist would break the chain identity continuity
+> guarantee that the sealed light client DB provides.
+
+### Preventing light client state loss
+
+To avoid the recovery procedure above, operators should:
+
+- **Keep the kernel running.** The light client state expires after the trusted period
+  (~2 weeks of inactivity). Restarting within this window resumes normally from the sealed DB.
+- **Monitor the kernel process.** If the kernel goes down, restart it promptly before the
+  trusted period expires.
+- **Do not delete files under `/opt/story-kernel/`.** The sealed light client DB and DKG
+  state are critical persistent data.
+
 ## Security Considerations
 
 - **Code Commitment**: The `mr_enclave` value uniquely identifies the enclave code. Any modification to the binary or the Gramine manifest changes this value.
@@ -374,6 +426,7 @@ The service exposes a gRPC API with the following methods:
 - **File Access**: The Gramine manifest restricts enclave file access to `/opt/story-kernel/` only. `/etc/ssl/certs/` is in `allowed_files` (not `trusted_files`) because CA certificate bundles differ across machines and would break MRENCLAVE reproducibility.
 - **Fixed Data Path**: The data directory is `/opt/story-kernel/` (not `~/.story-kernel/`) to ensure all validators produce the same MRENCLAVE regardless of OS user. See the [Data Directory](#data-directory) section for details.
 - **MRENCLAVE Reproducibility**: The entire Gramine manifest — every byte — is measured into the code commitment. All values that could vary (log level, binary name) are hardcoded in the manifest. See [Software Requirements](#software-requirements) for the exact versions required.
+- **Light Client Chain Identity**: After DKG registration, the kernel refuses to initialize the light client from `config.toml`. See the [Light Client Recovery](#light-client-recovery) section for the rationale and recovery procedure.
 
 ## Contributing
 

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -56,14 +57,14 @@ func Serve(cfg *config.Config) (*grpc.Server, chan error) {
 
 	svr := grpc.NewServer(serverOpts...)
 
-	// Initialize query client
-	queryClient, err := initializeQueryClient(cfg)
+	// Initialize query client and session nonce (bound to the light client DB instance).
+	queryClient, sessionNonce, err := initializeQueryClient(cfg)
 	if err != nil {
 		log.Fatalf("Failed to initialize query client: %v", err)
 	}
 
 	// Register story-kernel service server
-	registerAllServices(svr, cfg, queryClient)
+	registerAllServices(svr, cfg, queryClient, sessionNonce)
 
 	// Only enable gRPC reflection in debug mode for development/testing.
 	// Reflection exposes service metadata and must not be enabled in production.
@@ -88,12 +89,18 @@ func runServer(cfg *config.Config, svr *grpc.Server, errCh chan error) {
 	errCh <- svr.Serve(lis)
 }
 
-func initializeQueryClient(cfg *config.Config) (story.QueryClient, error) {
+func initializeQueryClient(cfg *config.Config) (story.QueryClient, []byte, error) {
 	// Create SGX-protected database for light client
 	lightClientDir := cfg.GetLightClientDir()
 	db, err := enclave.NewSealedLevelDB("light_client", lightClientDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create light client database: %w", err)
+		return nil, nil, fmt.Errorf("failed to create light client database: %w", err)
+	}
+
+	// Ensure a session nonce exists in the DB, binding sealed files to this DB instance.
+	sessionNonce, err := ensureSessionNonce(db)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to ensure session nonce: %w", err)
 	}
 
 	ctx := context.Background()
@@ -103,7 +110,7 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, error) {
 	// - If DB is empty (first-time startup): Create new instance from config's trusted block.
 	hasExistingState, err := story.HasTrustedState(db, cfg.LightClient.ChainID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check existing light client state: %w", err)
+		return nil, nil, fmt.Errorf("failed to check existing light client state: %w", err)
 	}
 
 	if hasExistingState {
@@ -116,31 +123,33 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, error) {
 			// NOT clear the DB — doing so would destroy valid state and cause a boot loop
 			// if the config's trusted block is also expired.
 			if !isDBStateError(err) {
-				return nil, fmt.Errorf("failed to resume light client from DB: %w", err)
+				return nil, nil, fmt.Errorf("failed to resume light client from DB: %w", err)
 			}
 
 			log.Warnf("Light client DB state is invalid, falling back to config's trusted block: %v", err)
 
 			queryClient, fallbackErr := fallbackToConfigTrustedBlock(ctx, cfg, db)
 			if fallbackErr != nil {
-				return nil, fmt.Errorf("failed to resume from DB (%w) and fallback from config also failed: %w", err, fallbackErr)
+				return nil, nil, fmt.Errorf("failed to resume from DB (%w) and fallback from config also failed: %w", err, fallbackErr)
 			}
 
-			return queryClient, nil
+			return queryClient, sessionNonce, nil
 		}
 
 		log.Info("Resumed light client from existing sealed state")
 
-		return queryClient, nil
+		return queryClient, sessionNonce, nil
 	}
 
 	// No existing state — first-time initialization from config.
-	// After DKG registration, the light client must only resume from sealed DB.
-	if err := rejectConfigFallbackIfDKGKeysExist(cfg); err != nil {
-		return nil, err
+	// Any pre-existing sealed DKG files from a prior DB session will fail
+	// nonce verification at use time, so no explicit file check is needed here.
+	qc, err := newQueryClientFromConfig(ctx, cfg, db)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return newQueryClientFromConfig(ctx, cfg, db)
+	return qc, sessionNonce, nil
 }
 
 // newQueryClientFromConfig creates a new verified query client using config's trusted block info.
@@ -204,16 +213,56 @@ func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cm
 	return queryClient, nil
 }
 
-// rejectConfigFallbackIfDKGKeysExist checks whether any sealed DKG key shares
-// exist. After DKG registration, the light client must resume from sealed DB
-// rather than config.toml to preserve chain identity continuity.
+// sessionNonceKey is the LevelDB key for the session nonce stored in the
+// light client's sealed database. The __kernel/ prefix avoids collisions
+// with CometBFT light client keys (which use lb/{chainID}/ and "size").
+// ClearTrustedState's store.Prune(0) only deletes light block keys, so
+// this nonce survives DB prune operations.
+var sessionNonceKey = []byte("__kernel/session_nonce")
+
+// ensureSessionNonce reads or creates a session nonce in the light client DB.
+// The nonce binds all sealed DKG files to this specific DB instance.
+// If the DB was re-created (e.g., after deletion), a new nonce is generated
+// and any pre-existing sealed DKG files will fail nonce verification at use time.
+func ensureSessionNonce(db cmtdb.DB) ([]byte, error) {
+	existing, err := db.Get(sessionNonceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session nonce from DB: %w", err)
+	}
+
+	if existing != nil {
+		if len(existing) != store.SessionNonceSize {
+			return nil, fmt.Errorf("corrupted session nonce in DB: expected %d bytes, got %d",
+				store.SessionNonceSize, len(existing))
+		}
+		return existing, nil
+	}
+
+	// No nonce in DB — generate a fresh one.
+	nonce := make([]byte, store.SessionNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate session nonce: %w", err)
+	}
+
+	if err := db.SetSync(sessionNonceKey, nonce); err != nil {
+		return nil, fmt.Errorf("failed to persist session nonce to DB: %w", err)
+	}
+
+	log.Info("Generated and stored new session nonce in DB")
+
+	return nonce, nil
+}
+
+// rejectConfigFallbackIfDKGKeysExist checks whether any sealed dist_key_share
+// files exist. After DKG finalization, the light client must resume from sealed
+// DB rather than config.toml to preserve chain identity continuity.
 func rejectConfigFallbackIfDKGKeysExist(cfg *config.Config) error {
-	hasKeys, err := store.HasAnyDistKeyShareInDir(cfg.GetDKGStateDir())
+	hasShares, err := store.HasAnyDistKeyShareInDir(cfg.GetDKGStateDir())
 	if err != nil {
 		return fmt.Errorf("failed to check for existing DKG key shares: %w", err)
 	}
 
-	if hasKeys {
+	if hasShares {
 		return fmt.Errorf(
 			"sealed DKG key shares exist but light client state is missing or expired. "+
 				"To recover, remove the DKG state directory (%s) and re-register",
@@ -292,8 +341,15 @@ func loadServerTLSCredentials(grpcCfg config.GRPCConfig) (credentials.TransportC
 	return credentials.NewTLS(tlsConfig), nil
 }
 
-func registerAllServices(svr *grpc.Server, cfg *config.Config, queryClient story.QueryClient) {
+func registerAllServices(svr *grpc.Server, cfg *config.Config, queryClient story.QueryClient, sessionNonce []byte) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	// Wrap the default SGX sealer with session nonce binding so that all sealed
+	// DKG files are tied to the current light client DB instance.
+	nonceSealer, err := store.NewNonceBindingSealer(store.NewEnclaveSealer(), sessionNonce)
+	if err != nil {
+		log.Fatalf("Failed to create nonce-binding sealer: %v", err)
+	}
 
 	pb.RegisterKernelServiceServer(svr, &service.DKGServer{
 		Cfg:                cfg,
@@ -304,7 +360,7 @@ func registerAllServices(svr *grpc.Server, cfg *config.Config, queryClient story
 		ResharingPrevCache: store.NewResharingDKGCache(),
 		ResharingNextCache: store.NewDKGCache(),
 		DistKeyShareCache:  store.NewDistKeyShareCache(),
-		DKGStore:           store.NewDKGStore(cfg.GetKeysDir(), cfg.GetDKGStateDir(), suite),
+		DKGStore:           store.NewDKGStoreWithSealer(cfg.GetKeysDir(), cfg.GetDKGStateDir(), suite, nonceSealer),
 		PIDCache:           store.NewPIDCache(),
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -133,6 +133,12 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, []byte, error
 				return nil, nil, fmt.Errorf("failed to resume from DB (%w) and fallback from config also failed: %w", err, fallbackErr)
 			}
 
+			// Re-read the nonce because fallbackToConfigTrustedBlock regenerates it.
+			sessionNonce, err = ensureSessionNonce(db)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to read regenerated session nonce: %w", err)
+			}
+
 			return queryClient, sessionNonce, nil
 		}
 
@@ -190,13 +196,20 @@ func newQueryClientFromConfig(ctx context.Context, cfg *config.Config, db cmtdb.
 // to update config.toml with a recent trusted block.
 func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cmtdb.DB) (story.QueryClient, error) {
 	// Check BEFORE ClearTrustedState to avoid irreversibly destroying valid DB state.
-	// After DKG registration, the light client must only resume from sealed DB.
+	// After DKG finalization, the light client must only resume from sealed DB.
 	if err := rejectConfigFallbackIfDKGKeysExist(cfg); err != nil {
 		return nil, err
 	}
 
 	if err := story.ClearTrustedState(db, cfg.LightClient.ChainID); err != nil {
 		return nil, fmt.Errorf("failed to clear expired light client state: %w", err)
+	}
+
+	// Regenerate the session nonce. Re-initializing from config.toml breaks chain
+	// identity continuity, so any sealed DKG files from the prior session must not
+	// be usable under the new light client state.
+	if err := regenerateSessionNonce(db); err != nil {
+		return nil, fmt.Errorf("failed to regenerate session nonce: %w", err)
 	}
 
 	queryClient, err := newQueryClientFromConfig(ctx, cfg, db)
@@ -251,6 +264,25 @@ func ensureSessionNonce(db cmtdb.DB) ([]byte, error) {
 	log.Info("Generated and stored new session nonce in DB")
 
 	return nonce, nil
+}
+
+// regenerateSessionNonce replaces the existing session nonce in the DB with a
+// fresh random value. This is called when falling back to config.toml for light
+// client re-initialization, which breaks chain identity continuity. Any sealed
+// DKG files created under the prior nonce will fail verification at use time.
+func regenerateSessionNonce(db cmtdb.DB) error {
+	nonce := make([]byte, store.SessionNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("failed to generate new session nonce: %w", err)
+	}
+
+	if err := db.SetSync(sessionNonceKey, nonce); err != nil {
+		return fmt.Errorf("failed to persist regenerated session nonce: %w", err)
+	}
+
+	log.Info("Regenerated session nonce for config-based light client re-initialization")
+
+	return nil
 }
 
 // rejectConfigFallbackIfDKGKeysExist checks whether any sealed dist_key_share

--- a/server/server.go
+++ b/server/server.go
@@ -97,22 +97,14 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, []byte, error
 		return nil, nil, fmt.Errorf("failed to create light client database: %w", err)
 	}
 
-	// Ensure a session nonce exists in the DB, binding sealed files to this DB instance.
-	sessionNonce, err := ensureSessionNonce(db)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to ensure session nonce: %w", err)
-	}
-
 	ctx := context.Background()
 
-	// Determine initialization strategy based on DB state, not config values.
-	// - If DB has existing light client state (from a previous run): Load from DB.
-	// - If DB is empty (first-time startup): Create new instance from config's trusted block.
 	hasExistingState, err := story.HasTrustedState(db, cfg.LightClient.ChainID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to check existing light client state: %w", err)
 	}
 
+	// If sealed DB has valid light client state, resume from it and use the existing nonce.
 	if hasExistingState {
 		log.Info("Found existing light client state in sealed DB, resuming...")
 		queryClient, err := story.LoadVerifiedQueryClient(ctx, cfg, db)
@@ -128,34 +120,42 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, []byte, error
 
 			log.Warnf("Light client DB state is invalid, falling back to config's trusted block: %v", err)
 
-			queryClient, fallbackErr := fallbackToConfigTrustedBlock(ctx, cfg, db)
-			if fallbackErr != nil {
-				return nil, nil, fmt.Errorf("failed to resume from DB (%w) and fallback from config also failed: %w", err, fallbackErr)
-			}
-
-			// Re-read the nonce because fallbackToConfigTrustedBlock regenerates it.
-			sessionNonce, err = ensureSessionNonce(db)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read regenerated session nonce: %w", err)
-			}
-
-			return queryClient, sessionNonce, nil
+			return initFromConfig(ctx, cfg, db)
 		}
 
 		log.Info("Resumed light client from existing sealed state")
 
-		return queryClient, sessionNonce, nil
+		nonce, err := readSessionNonce(db)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read session nonce: %w", err)
+		}
+
+		return queryClient, nonce, nil
 	}
 
-	// No existing state — first-time initialization from config.
-	// Any pre-existing sealed DKG files from a prior DB session will fail
-	// nonce verification at use time, so no explicit file check is needed here.
+	// No existing light client state — initialize from config.toml.
+	return initFromConfig(ctx, cfg, db)
+}
+
+// initFromConfig initializes the light client from config.toml with a fresh session nonce.
+// Every config-based initialization (first boot, expired DB fallback, etc.) generates a
+// new nonce, invalidating any sealed DKG files from a prior session.
+func initFromConfig(ctx context.Context, cfg *config.Config, db cmtdb.DB) (story.QueryClient, []byte, error) {
+	if err := story.ClearTrustedState(db, cfg.LightClient.ChainID); err != nil {
+		return nil, nil, fmt.Errorf("failed to clear light client state: %w", err)
+	}
+
+	nonce, err := writeNewSessionNonce(db)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to write session nonce: %w", err)
+	}
+
 	qc, err := newQueryClientFromConfig(ctx, cfg, db)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to initialize light client from config: %w", err)
 	}
 
-	return qc, sessionNonce, nil
+	return qc, nonce, nil
 }
 
 // newQueryClientFromConfig creates a new verified query client using config's trusted block info.
@@ -189,43 +189,6 @@ func newQueryClientFromConfig(ctx context.Context, cfg *config.Config, db cmtdb.
 	return queryClient, nil
 }
 
-// fallbackToConfigTrustedBlock clears expired light client state and re-initializes from config.
-// This handles the case where the story-kernel was offline longer than the trusted period (~2 weeks),
-// causing the stored light client state to expire.
-// If the config's trusted block is also expired, returns an actionable error asking the operator
-// to update config.toml with a recent trusted block.
-func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cmtdb.DB) (story.QueryClient, error) {
-	// Check BEFORE ClearTrustedState to avoid irreversibly destroying valid DB state.
-	// After DKG finalization, the light client must only resume from sealed DB.
-	if err := rejectConfigFallbackIfDKGKeysExist(cfg); err != nil {
-		return nil, err
-	}
-
-	if err := story.ClearTrustedState(db, cfg.LightClient.ChainID); err != nil {
-		return nil, fmt.Errorf("failed to clear expired light client state: %w", err)
-	}
-
-	// Regenerate the session nonce. Re-initializing from config.toml breaks chain
-	// identity continuity, so any sealed DKG files from the prior session must not
-	// be usable under the new light client state.
-	if err := regenerateSessionNonce(db); err != nil {
-		return nil, fmt.Errorf("failed to regenerate session nonce: %w", err)
-	}
-
-	queryClient, err := newQueryClientFromConfig(ctx, cfg, db)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"config's trusted block (height=%d, hash=%s) is also expired or invalid: %w. Please update trusted_height and trusted_hash in config.toml with a recent block (within the trusted period)",
-			cfg.LightClient.TrustedHeight, cfg.LightClient.TrustedHash, err,
-		)
-	}
-
-	log.Warn("Re-initialized light client from config's trusted block after clearing expired DB state")
-	log.Info("Consider updating trusted_height and trusted_hash in config.toml with a more recent block to avoid this on future restarts")
-
-	return queryClient, nil
-}
-
 // sessionNonceKey is the LevelDB key for the session nonce stored in the
 // light client's sealed database. The __kernel/ prefix avoids collisions
 // with CometBFT light client keys (which use lb/{chainID}/ and "size").
@@ -233,25 +196,30 @@ func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cm
 // this nonce survives DB prune operations.
 var sessionNonceKey = []byte("__kernel/session_nonce")
 
-// ensureSessionNonce reads or creates a session nonce in the light client DB.
-// The nonce binds all sealed DKG files to this specific DB instance.
-// If the DB was re-created (e.g., after deletion), a new nonce is generated
-// and any pre-existing sealed DKG files will fail nonce verification at use time.
-func ensureSessionNonce(db cmtdb.DB) ([]byte, error) {
-	existing, err := db.Get(sessionNonceKey)
+// readSessionNonce reads the existing session nonce from the light client DB.
+// Returns an error if the nonce is missing or corrupted.
+func readSessionNonce(db cmtdb.DB) ([]byte, error) {
+	nonce, err := db.Get(sessionNonceKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read session nonce from DB: %w", err)
 	}
 
-	if existing != nil {
-		if len(existing) != store.SessionNonceSize {
-			return nil, fmt.Errorf("corrupted session nonce in DB: expected %d bytes, got %d",
-				store.SessionNonceSize, len(existing))
-		}
-		return existing, nil
+	if nonce == nil {
+		return nil, errors.New("session nonce not found in DB")
 	}
 
-	// No nonce in DB — generate a fresh one.
+	if len(nonce) != store.SessionNonceSize {
+		return nil, fmt.Errorf("corrupted session nonce in DB: expected %d bytes, got %d",
+			store.SessionNonceSize, len(nonce))
+	}
+
+	return nonce, nil
+}
+
+// writeNewSessionNonce generates a fresh random session nonce and stores it in the DB,
+// replacing any existing nonce. This is called on every config-based light client
+// initialization to ensure sealed DKG files from a prior session are invalidated.
+func writeNewSessionNonce(db cmtdb.DB) ([]byte, error) {
 	nonce := make([]byte, store.SessionNonceSize)
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate session nonce: %w", err)
@@ -261,48 +229,9 @@ func ensureSessionNonce(db cmtdb.DB) ([]byte, error) {
 		return nil, fmt.Errorf("failed to persist session nonce to DB: %w", err)
 	}
 
-	log.Info("Generated and stored new session nonce in DB")
+	log.Info("Generated new session nonce")
 
 	return nonce, nil
-}
-
-// regenerateSessionNonce replaces the existing session nonce in the DB with a
-// fresh random value. This is called when falling back to config.toml for light
-// client re-initialization, which breaks chain identity continuity. Any sealed
-// DKG files created under the prior nonce will fail verification at use time.
-func regenerateSessionNonce(db cmtdb.DB) error {
-	nonce := make([]byte, store.SessionNonceSize)
-	if _, err := rand.Read(nonce); err != nil {
-		return fmt.Errorf("failed to generate new session nonce: %w", err)
-	}
-
-	if err := db.SetSync(sessionNonceKey, nonce); err != nil {
-		return fmt.Errorf("failed to persist regenerated session nonce: %w", err)
-	}
-
-	log.Info("Regenerated session nonce for config-based light client re-initialization")
-
-	return nil
-}
-
-// rejectConfigFallbackIfDKGKeysExist checks whether any sealed dist_key_share
-// files exist. After DKG finalization, the light client must resume from sealed
-// DB rather than config.toml to preserve chain identity continuity.
-func rejectConfigFallbackIfDKGKeysExist(cfg *config.Config) error {
-	hasShares, err := store.HasAnyDistKeyShareInDir(cfg.GetDKGStateDir())
-	if err != nil {
-		return fmt.Errorf("failed to check for existing DKG key shares: %w", err)
-	}
-
-	if hasShares {
-		return fmt.Errorf(
-			"sealed DKG key shares exist but light client state is missing or expired. "+
-				"To recover, remove the DKG state directory (%s) and re-register",
-			cfg.GetDKGStateDir(),
-		)
-	}
-
-	return nil
 }
 
 // isDBStateError reports whether err indicates the light client's stored state is

--- a/server/server.go
+++ b/server/server.go
@@ -135,6 +135,11 @@ func initializeQueryClient(cfg *config.Config) (story.QueryClient, error) {
 	}
 
 	// No existing state — first-time initialization from config.
+	// After DKG registration, the light client must only resume from sealed DB.
+	if err := rejectConfigFallbackIfDKGKeysExist(cfg); err != nil {
+		return nil, err
+	}
+
 	return newQueryClientFromConfig(ctx, cfg, db)
 }
 
@@ -175,6 +180,12 @@ func newQueryClientFromConfig(ctx context.Context, cfg *config.Config, db cmtdb.
 // If the config's trusted block is also expired, returns an actionable error asking the operator
 // to update config.toml with a recent trusted block.
 func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cmtdb.DB) (story.QueryClient, error) {
+	// Check BEFORE ClearTrustedState to avoid irreversibly destroying valid DB state.
+	// After DKG registration, the light client must only resume from sealed DB.
+	if err := rejectConfigFallbackIfDKGKeysExist(cfg); err != nil {
+		return nil, err
+	}
+
 	if err := story.ClearTrustedState(db, cfg.LightClient.ChainID); err != nil {
 		return nil, fmt.Errorf("failed to clear expired light client state: %w", err)
 	}
@@ -191,6 +202,26 @@ func fallbackToConfigTrustedBlock(ctx context.Context, cfg *config.Config, db cm
 	log.Info("Consider updating trusted_height and trusted_hash in config.toml with a more recent block to avoid this on future restarts")
 
 	return queryClient, nil
+}
+
+// rejectConfigFallbackIfDKGKeysExist checks whether any sealed DKG key shares
+// exist. After DKG registration, the light client must resume from sealed DB
+// rather than config.toml to preserve chain identity continuity.
+func rejectConfigFallbackIfDKGKeysExist(cfg *config.Config) error {
+	hasKeys, err := store.HasAnyDistKeyShareInDir(cfg.GetDKGStateDir())
+	if err != nil {
+		return fmt.Errorf("failed to check for existing DKG key shares: %w", err)
+	}
+
+	if hasKeys {
+		return fmt.Errorf(
+			"sealed DKG key shares exist but light client state is missing or expired. "+
+				"To recover, remove the DKG state directory (%s) and re-register",
+			cfg.GetDKGStateDir(),
+		)
+	}
+
+	return nil
 }
 
 // isDBStateError reports whether err indicates the light client's stored state is

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piplabs/story-kernel/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRejectConfigFallbackIfDKGKeysExist_NoKeys verifies that first-boot
+// (no dist_key_share.sealed anywhere) is allowed through.
+func TestRejectConfigFallbackIfDKGKeysExist_NoKeys(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.SetHomeDir(dir)
+
+	// Ensure the DKG state directory exists but is empty.
+	require.NoError(t, os.MkdirAll(cfg.GetDKGStateDir(), 0o700))
+
+	err := rejectConfigFallbackIfDKGKeysExist(cfg)
+	require.NoError(t, err, "first boot with no DKG keys should be allowed")
+}
+
+// TestRejectConfigFallbackIfDKGKeysExist_WithKeys verifies that the fallback
+// is rejected when sealed DKG key shares exist.
+func TestRejectConfigFallbackIfDKGKeysExist_WithKeys(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.SetHomeDir(dir)
+
+	// Create a dist_key_share.sealed in the expected structure.
+	shareDir := filepath.Join(cfg.GetDKGStateDir(), "1", "abcdef0123456789")
+	require.NoError(t, os.MkdirAll(shareDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(shareDir, config.DistKeyShareFile),
+		[]byte("sealed-data"), 0o600,
+	))
+
+	err := rejectConfigFallbackIfDKGKeysExist(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sealed DKG key shares exist")
+	require.Contains(t, err.Error(), "re-register")
+}
+
+// TestRejectConfigFallbackIfDKGKeysExist_NoDKGStateDir verifies that a missing
+// DKG state directory (completely fresh install) is allowed.
+func TestRejectConfigFallbackIfDKGKeysExist_NoDKGStateDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.SetHomeDir(dir)
+
+	// Do NOT create the DKG state directory — simulate fresh install.
+	err := rejectConfigFallbackIfDKGKeysExist(cfg)
+	require.NoError(t, err, "fresh install with no DKG state dir should be allowed")
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	cmtdb "github.com/cometbft/cometbft-db"
 	"github.com/piplabs/story-kernel/config"
+	"github.com/piplabs/story-kernel/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,4 +62,36 @@ func TestRejectConfigFallbackIfDKGKeysExist_NoDKGStateDir(t *testing.T) {
 	// Do NOT create the DKG state directory — simulate fresh install.
 	err := rejectConfigFallbackIfDKGKeysExist(cfg)
 	require.NoError(t, err, "fresh install with no DKG state dir should be allowed")
+}
+
+// =============================================================================
+// ensureSessionNonce tests
+// =============================================================================
+
+// TestEnsureSessionNonce_NewDB verifies that a fresh DB generates a new session nonce.
+func TestEnsureSessionNonce_NewDB(t *testing.T) {
+	t.Parallel()
+
+	db := cmtdb.NewMemDB()
+
+	nonce, err := ensureSessionNonce(db)
+	require.NoError(t, err)
+	require.Len(t, nonce, store.SessionNonceSize)
+}
+
+// TestEnsureSessionNonce_ExistingDB verifies that a DB with an existing nonce
+// returns the same nonce.
+func TestEnsureSessionNonce_ExistingDB(t *testing.T) {
+	t.Parallel()
+
+	db := cmtdb.NewMemDB()
+
+	// Generate nonce on first call.
+	nonce1, err := ensureSessionNonce(db)
+	require.NoError(t, err)
+
+	// Second call returns the same nonce.
+	nonce2, err := ensureSessionNonce(db)
+	require.NoError(t, err)
+	require.Equal(t, nonce1, nonce2)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,97 +1,86 @@
 package server
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	cmtdb "github.com/cometbft/cometbft-db"
-	"github.com/piplabs/story-kernel/config"
 	"github.com/piplabs/story-kernel/store"
 	"github.com/stretchr/testify/require"
 )
 
-// TestRejectConfigFallbackIfDKGKeysExist_NoKeys verifies that first-boot
-// (no dist_key_share.sealed anywhere) is allowed through.
-func TestRejectConfigFallbackIfDKGKeysExist_NoKeys(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfg := &config.Config{}
-	cfg.SetHomeDir(dir)
-
-	// Ensure the DKG state directory exists but is empty.
-	require.NoError(t, os.MkdirAll(cfg.GetDKGStateDir(), 0o700))
-
-	err := rejectConfigFallbackIfDKGKeysExist(cfg)
-	require.NoError(t, err, "first boot with no DKG keys should be allowed")
-}
-
-// TestRejectConfigFallbackIfDKGKeysExist_WithKeys verifies that the fallback
-// is rejected when sealed DKG key shares exist.
-func TestRejectConfigFallbackIfDKGKeysExist_WithKeys(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfg := &config.Config{}
-	cfg.SetHomeDir(dir)
-
-	// Create a dist_key_share.sealed in the expected structure.
-	shareDir := filepath.Join(cfg.GetDKGStateDir(), "1", "abcdef0123456789")
-	require.NoError(t, os.MkdirAll(shareDir, 0o700))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(shareDir, config.DistKeyShareFile),
-		[]byte("sealed-data"), 0o600,
-	))
-
-	err := rejectConfigFallbackIfDKGKeysExist(cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "sealed DKG key shares exist")
-	require.Contains(t, err.Error(), "re-register")
-}
-
-// TestRejectConfigFallbackIfDKGKeysExist_NoDKGStateDir verifies that a missing
-// DKG state directory (completely fresh install) is allowed.
-func TestRejectConfigFallbackIfDKGKeysExist_NoDKGStateDir(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfg := &config.Config{}
-	cfg.SetHomeDir(dir)
-
-	// Do NOT create the DKG state directory — simulate fresh install.
-	err := rejectConfigFallbackIfDKGKeysExist(cfg)
-	require.NoError(t, err, "fresh install with no DKG state dir should be allowed")
-}
-
 // =============================================================================
-// ensureSessionNonce tests
+// writeNewSessionNonce tests
 // =============================================================================
 
-// TestEnsureSessionNonce_NewDB verifies that a fresh DB generates a new session nonce.
-func TestEnsureSessionNonce_NewDB(t *testing.T) {
+// TestWriteNewSessionNonce generates a valid nonce and persists it.
+func TestWriteNewSessionNonce(t *testing.T) {
 	t.Parallel()
 
 	db := cmtdb.NewMemDB()
 
-	nonce, err := ensureSessionNonce(db)
+	nonce, err := writeNewSessionNonce(db)
 	require.NoError(t, err)
 	require.Len(t, nonce, store.SessionNonceSize)
+
+	// Verify it was persisted.
+	stored, err := db.Get(sessionNonceKey)
+	require.NoError(t, err)
+	require.Equal(t, nonce, stored)
 }
 
-// TestEnsureSessionNonce_ExistingDB verifies that a DB with an existing nonce
-// returns the same nonce.
-func TestEnsureSessionNonce_ExistingDB(t *testing.T) {
+// TestWriteNewSessionNonce_OverwritesPrevious verifies that a second call
+// replaces the nonce (not appends or fails).
+func TestWriteNewSessionNonce_OverwritesPrevious(t *testing.T) {
 	t.Parallel()
 
 	db := cmtdb.NewMemDB()
 
-	// Generate nonce on first call.
-	nonce1, err := ensureSessionNonce(db)
+	nonce1, err := writeNewSessionNonce(db)
 	require.NoError(t, err)
 
-	// Second call returns the same nonce.
-	nonce2, err := ensureSessionNonce(db)
+	nonce2, err := writeNewSessionNonce(db)
 	require.NoError(t, err)
-	require.Equal(t, nonce1, nonce2)
+
+	require.NotEqual(t, nonce1, nonce2, "each call must produce a fresh nonce")
+}
+
+// =============================================================================
+// readSessionNonce tests
+// =============================================================================
+
+// TestReadSessionNonce_AfterWrite reads back a previously written nonce.
+func TestReadSessionNonce_AfterWrite(t *testing.T) {
+	t.Parallel()
+
+	db := cmtdb.NewMemDB()
+
+	written, err := writeNewSessionNonce(db)
+	require.NoError(t, err)
+
+	read, err := readSessionNonce(db)
+	require.NoError(t, err)
+	require.Equal(t, written, read)
+}
+
+// TestReadSessionNonce_EmptyDB returns error when no nonce exists.
+func TestReadSessionNonce_EmptyDB(t *testing.T) {
+	t.Parallel()
+
+	db := cmtdb.NewMemDB()
+
+	_, err := readSessionNonce(db)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+// TestReadSessionNonce_CorruptedLength returns error when nonce has wrong length.
+func TestReadSessionNonce_CorruptedLength(t *testing.T) {
+	t.Parallel()
+
+	db := cmtdb.NewMemDB()
+	require.NoError(t, db.Set(sessionNonceKey, []byte("too-short")))
+
+	_, err := readSessionNonce(db)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "corrupted")
 }

--- a/service/dkg_partial_decrypt.go
+++ b/service/dkg_partial_decrypt.go
@@ -147,11 +147,18 @@ func (s *DKGServer) PartialDecryptTDH2(ctx context.Context, req *pb.PartialDecry
 		"priv_share_len": len(privShare.Bytes),
 	}).Info("TDH2 partial decrypt: inputs")
 
-	// Verify ciphertext independently before attempting partial decrypt
+	// Verify ciphertext before attempting partial decrypt.
+	// Reject invalid ciphertexts before using sealed key material.
 	verifyErr := mpc.TDH2Verify(pubKey, ct.Bytes, req.GetLabel())
-	log.WithFields(log.Fields{
-		"verify_result": verifyErr,
-	}).Info("TDH2 partial decrypt: ciphertext verify")
+	if verifyErr != nil {
+		log.WithFields(log.Fields{
+			"round":           req.GetRound(),
+			"code_commitment": codeCommitmentHex,
+			"verify_error":    verifyErr.Error(),
+		}).Error("TDH2 ciphertext verification failed")
+
+		return nil, status.Errorf(codes.InvalidArgument, "ciphertext verification failed")
+	}
 
 	pd, err := mpc.TDH2PartialDecrypt(int(ownPID), privShare, pubKey, ct, req.GetLabel())
 	if err != nil {

--- a/service/dkg_partial_decrypt_e2e_test.go
+++ b/service/dkg_partial_decrypt_e2e_test.go
@@ -221,3 +221,68 @@ func TestTDH2ServiceWithRequesterEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, plaintext, recovered)
 }
+
+// TestTDH2VerifyRejectsInvalidCiphertext verifies that TDH2Verify returns a
+// non-nil error for corrupted or garbage ciphertext, confirming that the
+// enforcement gate in PartialDecryptTDH2 will block invalid inputs.
+func TestTDH2VerifyRejectsInvalidCiphertext(t *testing.T) {
+	const (
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	pubKey, _, _, _, _ := shamirSetup(t, suite, n, threshold)
+
+	label := []byte("verify-reject-label")
+
+	t.Run("garbage ciphertext bytes", func(t *testing.T) {
+		garbageCT := make([]byte, 256)
+		for i := range garbageCT {
+			garbageCT[i] = byte(i)
+		}
+
+		err := mpc.TDH2Verify(pubKey, garbageCT, label)
+		require.Error(t, err, "TDH2Verify must reject garbage ciphertext")
+	})
+
+	t.Run("empty ciphertext", func(t *testing.T) {
+		err := mpc.TDH2Verify(pubKey, []byte{}, label)
+		require.Error(t, err, "TDH2Verify must reject empty ciphertext")
+	})
+
+	t.Run("valid ciphertext passes", func(t *testing.T) {
+		plaintext := []byte("valid-data")
+		ct, err := mpc.TDH2Encrypt(pubKey, plaintext, label)
+		require.NoError(t, err)
+
+		err = mpc.TDH2Verify(pubKey, ct.Bytes, label)
+		require.NoError(t, err, "TDH2Verify must accept valid ciphertext")
+	})
+
+	t.Run("corrupted valid ciphertext", func(t *testing.T) {
+		plaintext := []byte("corrupt-me")
+		ct, err := mpc.TDH2Encrypt(pubKey, plaintext, label)
+		require.NoError(t, err)
+
+		// Corrupt a byte in the ciphertext
+		corrupted := make([]byte, len(ct.Bytes))
+		copy(corrupted, ct.Bytes)
+		if len(corrupted) > 10 {
+			corrupted[10] ^= 0xFF
+		}
+
+		err = mpc.TDH2Verify(pubKey, corrupted, label)
+		require.Error(t, err, "TDH2Verify must reject corrupted ciphertext")
+	})
+
+	t.Run("wrong label", func(t *testing.T) {
+		plaintext := []byte("wrong-label-test")
+		ct, err := mpc.TDH2Encrypt(pubKey, plaintext, label)
+		require.NoError(t, err)
+
+		wrongLabel := []byte("different-label")
+		err = mpc.TDH2Verify(pubKey, ct.Bytes, wrongLabel)
+		require.Error(t, err, "TDH2Verify must reject ciphertext verified with wrong label")
+	})
+}

--- a/store/dkg_store.go
+++ b/store/dkg_store.go
@@ -139,8 +139,7 @@ func HasAnyDistKeyShareInDir(stateDir string) (bool, error) {
 		roundPath := filepath.Join(stateDir, roundEntry.Name())
 		commitEntries, err := os.ReadDir(roundPath)
 		if err != nil {
-			// Skip unreadable round directories rather than failing hard.
-			continue
+			return false, fmt.Errorf("failed to read round directory %s: %w", roundPath, err)
 		}
 
 		for _, commitEntry := range commitEntries {

--- a/store/dkg_store.go
+++ b/store/dkg_store.go
@@ -103,3 +103,57 @@ func (s *DKGStore) LoadDistKeyShare(codeCommitmentHex string, round uint32) (*dk
 
 	return share, nil
 }
+
+// HasAnyDistKeyShare checks whether any dist_key_share.sealed file exists in
+// this store's state directory.
+func (s *DKGStore) HasAnyDistKeyShare() (bool, error) {
+	return HasAnyDistKeyShareInDir(s.stateDir)
+}
+
+// HasAnyDistKeyShareInDir walks the given DKG state directory to check whether
+// any dist_key_share.sealed file exists under any round/codeCommitment
+// subdirectory. The directory layout is:
+//
+//	{stateDir}/{round}/{codeCommitment}/dist_key_share.sealed
+//
+// After DKG registration, the light client must resume from sealed DB rather
+// than config.toml to preserve chain identity continuity. If the directory does
+// not exist, it returns (false, nil).
+func HasAnyDistKeyShareInDir(stateDir string) (bool, error) {
+	if _, err := os.Stat(stateDir); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to stat DKG state dir: %w", err)
+	}
+
+	roundEntries, err := os.ReadDir(stateDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to read DKG state dir: %w", err)
+	}
+
+	for _, roundEntry := range roundEntries {
+		if !roundEntry.IsDir() {
+			continue
+		}
+
+		roundPath := filepath.Join(stateDir, roundEntry.Name())
+		commitEntries, err := os.ReadDir(roundPath)
+		if err != nil {
+			// Skip unreadable round directories rather than failing hard.
+			continue
+		}
+
+		for _, commitEntry := range commitEntries {
+			if !commitEntry.IsDir() {
+				continue
+			}
+
+			sharePath := filepath.Join(roundPath, commitEntry.Name(), config.DistKeyShareFile)
+			if _, err := os.Stat(sharePath); err == nil {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/store/dkg_store.go
+++ b/store/dkg_store.go
@@ -39,6 +39,11 @@ func (enclaveSealer) UnsealFromFile(path string) ([]byte, error) {
 	return enclave.UnsealFromFile(path)
 }
 
+// NewEnclaveSealer returns a Sealer that delegates to the SGX enclave.
+func NewEnclaveSealer() Sealer {
+	return enclaveSealer{}
+}
+
 type DKGStore struct {
 	suite  *edwards25519.SuiteEd25519
 	sealer Sealer
@@ -51,7 +56,7 @@ type DKGStore struct {
 func NewDKGStore(keyDir, stateDir string, suite *edwards25519.SuiteEd25519) *DKGStore {
 	return &DKGStore{
 		suite:    suite,
-		sealer:   enclaveSealer{},
+		sealer:   NewEnclaveSealer(),
 		keyDir:   keyDir,
 		stateDir: stateDir,
 	}

--- a/store/dkg_store_keygate_test.go
+++ b/store/dkg_store_keygate_test.go
@@ -101,6 +101,25 @@ func TestHasAnyDistKeyShareInDir_FilesAtRoundLevel(t *testing.T) {
 	require.False(t, has)
 }
 
+// TestHasAnyDistKeyShareInDir_UnreadableRoundDir verifies that an unreadable round
+// directory causes an error (fail-closed) rather than being silently skipped.
+func TestHasAnyDistKeyShareInDir_UnreadableRoundDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create a round directory and make it unreadable.
+	roundDir := filepath.Join(dir, "1")
+	require.NoError(t, os.MkdirAll(roundDir, 0o700))
+	require.NoError(t, os.Chmod(roundDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(roundDir, 0o700) })
+
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.Error(t, err, "unreadable round directory should cause an error, not be skipped")
+	require.False(t, has)
+	require.Contains(t, err.Error(), "failed to read round directory")
+}
+
 // TestHasAnyDistKeyShare_ViaMethod verifies the DKGStore method delegates correctly.
 func TestHasAnyDistKeyShare_ViaMethod(t *testing.T) {
 	t.Parallel()

--- a/store/dkg_store_keygate_test.go
+++ b/store/dkg_store_keygate_test.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piplabs/story-kernel/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasAnyDistKeyShareInDir_EmptyDir verifies that an empty directory returns false.
+func TestHasAnyDistKeyShareInDir_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestHasAnyDistKeyShareInDir_NonExistentDir verifies that a non-existent directory returns false.
+func TestHasAnyDistKeyShareInDir_NonExistentDir(t *testing.T) {
+	t.Parallel()
+
+	has, err := HasAnyDistKeyShareInDir("/nonexistent/path/that/does/not/exist")
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestHasAnyDistKeyShareInDir_WithDistKeyShare verifies that a directory containing
+// a dist_key_share.sealed file in the expected nested structure returns true.
+func TestHasAnyDistKeyShareInDir_WithDistKeyShare(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create the nested structure: {dir}/1/abcdef/dist_key_share.sealed
+	shareDir := filepath.Join(dir, "1", "abcdef0123456789")
+	require.NoError(t, os.MkdirAll(shareDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(shareDir, config.DistKeyShareFile), []byte("sealed-data"), 0o600))
+
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+// TestHasAnyDistKeyShareInDir_MultipleRounds verifies detection across multiple round directories.
+func TestHasAnyDistKeyShareInDir_MultipleRounds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Round 1 exists but has no dist_key_share.sealed
+	round1Dir := filepath.Join(dir, "1", "commit_a")
+	require.NoError(t, os.MkdirAll(round1Dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(round1Dir, DKGStateFile), []byte("{}"), 0o600))
+
+	// Round 2 has a dist_key_share.sealed
+	round2Dir := filepath.Join(dir, "2", "commit_b")
+	require.NoError(t, os.MkdirAll(round2Dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(round2Dir, config.DistKeyShareFile), []byte("sealed-data"), 0o600))
+
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+// TestHasAnyDistKeyShareInDir_OtherFilesOnly verifies that other sealed files
+// (e.g., state.json, ed25519_priv.sealed) are not mistaken for dist_key_share.sealed.
+func TestHasAnyDistKeyShareInDir_OtherFilesOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	roundDir := filepath.Join(dir, "1", "commit_a")
+	require.NoError(t, os.MkdirAll(roundDir, 0o700))
+
+	// Create other files that should NOT trigger the check
+	require.NoError(t, os.WriteFile(filepath.Join(roundDir, DKGStateFile), []byte("{}"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(roundDir, KeyEd25519File), []byte("key"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(roundDir, PrivateCoeffsFile), []byte("coeffs"), 0o600))
+
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestHasAnyDistKeyShareInDir_FilesAtRoundLevel verifies that files directly
+// under the state dir (not in the round/commit structure) are ignored.
+func TestHasAnyDistKeyShareInDir_FilesAtRoundLevel(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A file at the round level (not a directory) should be skipped
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stray_file"), []byte("data"), 0o600))
+
+	has, err := HasAnyDistKeyShareInDir(dir)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestHasAnyDistKeyShare_ViaMethod verifies the DKGStore method delegates correctly.
+func TestHasAnyDistKeyShare_ViaMethod(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "dkg_state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+
+	store := NewDKGStoreWithSealer(filepath.Join(dir, "keys"), stateDir, nil, nil)
+
+	// Empty — no shares
+	has, err := store.HasAnyDistKeyShare()
+	require.NoError(t, err)
+	require.False(t, has)
+
+	// Create a dist_key_share.sealed
+	shareDir := filepath.Join(stateDir, "5", "deadbeef")
+	require.NoError(t, os.MkdirAll(shareDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(shareDir, config.DistKeyShareFile), []byte("sealed"), 0o600))
+
+	has, err = store.HasAnyDistKeyShare()
+	require.NoError(t, err)
+	require.True(t, has)
+}

--- a/store/nonce_sealer.go
+++ b/store/nonce_sealer.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const (
+	// SessionNonceSize is the byte length of the session nonce used to bind
+	// sealed files to a specific light client DB instance.
+	SessionNonceSize = 32
+)
+
+// NonceBindingSealer wraps a Sealer to prepend a session nonce to all sealed data.
+// On seal, the nonce is prepended before the payload.
+// On unseal, the nonce prefix is verified against the expected nonce.
+//
+// This ensures that sealed files created under one light client DB session
+// cannot be used with a different DB instance. The in-memory cache
+// (DistKeyShareCache) is safe because it is cleared on restart, and a restart
+// is required to change the DB session nonce.
+type NonceBindingSealer struct {
+	inner Sealer
+	nonce []byte // SessionNonceSize bytes
+}
+
+// NewNonceBindingSealer creates a NonceBindingSealer that wraps inner with the
+// given session nonce. The nonce must be exactly SessionNonceSize bytes.
+func NewNonceBindingSealer(inner Sealer, nonce []byte) (*NonceBindingSealer, error) {
+	if len(nonce) != SessionNonceSize {
+		return nil, fmt.Errorf("session nonce must be %d bytes, got %d", SessionNonceSize, len(nonce))
+	}
+
+	cp := make([]byte, SessionNonceSize)
+	copy(cp, nonce)
+
+	return &NonceBindingSealer{inner: inner, nonce: cp}, nil
+}
+
+// SealToFile prepends the session nonce to data and delegates to the inner Sealer.
+func (s *NonceBindingSealer) SealToFile(data []byte, path string) error {
+	bound := make([]byte, len(s.nonce)+len(data))
+	copy(bound, s.nonce)
+	copy(bound[len(s.nonce):], data)
+
+	return s.inner.SealToFile(bound, path)
+}
+
+// UnsealFromFile delegates to the inner Sealer and verifies the session nonce prefix.
+// Returns an error if the unsealed data is too short or the nonce does not match.
+func (s *NonceBindingSealer) UnsealFromFile(path string) ([]byte, error) {
+	raw, err := s.inner.UnsealFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(raw) < len(s.nonce) {
+		return nil, fmt.Errorf("session nonce mismatch: sealed data too short (expected at least %d bytes, got %d)", len(s.nonce), len(raw))
+	}
+
+	if !bytes.Equal(raw[:len(s.nonce)], s.nonce) {
+		return nil, fmt.Errorf("session nonce mismatch: sealed data was created in a different DB session")
+	}
+
+	return raw[len(s.nonce):], nil
+}

--- a/store/nonce_sealer_test.go
+++ b/store/nonce_sealer_test.go
@@ -1,0 +1,185 @@
+package store
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNonceBindingSealer_RoundTrip verifies that data sealed with the correct
+// nonce can be unsealed successfully.
+func TestNonceBindingSealer_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sealed")
+	payload := []byte("hello world")
+
+	require.NoError(t, sealer.SealToFile(payload, path))
+
+	got, err := sealer.UnsealFromFile(path)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+// TestNonceBindingSealer_WrongNonce verifies that data sealed with one nonce
+// cannot be unsealed with a different nonce.
+func TestNonceBindingSealer_WrongNonce(t *testing.T) {
+	t.Parallel()
+
+	nonce1 := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce1)
+	require.NoError(t, err)
+
+	nonce2 := make([]byte, SessionNonceSize)
+	_, err = rand.Read(nonce2)
+	require.NoError(t, err)
+
+	sealer1, err := NewNonceBindingSealer(plaintextSealer{}, nonce1)
+	require.NoError(t, err)
+	sealer2, err := NewNonceBindingSealer(plaintextSealer{}, nonce2)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sealed")
+	payload := []byte("secret data")
+
+	require.NoError(t, sealer1.SealToFile(payload, path))
+
+	_, err = sealer2.UnsealFromFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session nonce mismatch")
+}
+
+// TestNonceBindingSealer_DataTooShort verifies that data shorter than the nonce
+// length returns an error.
+func TestNonceBindingSealer_DataTooShort(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "short.sealed")
+
+	// Write raw data shorter than nonce length (bypass NonceBindingSealer)
+	require.NoError(t, os.WriteFile(path, []byte("short"), 0o600))
+
+	_, err = sealer.UnsealFromFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too short")
+}
+
+// TestNonceBindingSealer_EmptyPayload verifies that sealing and unsealing an
+// empty payload works correctly (nonce-only file).
+func TestNonceBindingSealer_EmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.sealed")
+
+	require.NoError(t, sealer.SealToFile([]byte{}, path))
+
+	got, err := sealer.UnsealFromFile(path)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestNonceBindingSealer_PrependsAndStripsNonce verifies the raw file content
+// has the nonce prepended, and unsealing strips it correctly.
+func TestNonceBindingSealer_PrependsAndStripsNonce(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "check.sealed")
+	payload := []byte("payload-data")
+
+	require.NoError(t, sealer.SealToFile(payload, path))
+
+	// Read raw file to verify nonce is prepended (plaintextSealer writes raw)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Len(t, raw, SessionNonceSize+len(payload))
+	require.Equal(t, nonce, raw[:SessionNonceSize])
+	require.Equal(t, payload, raw[SessionNonceSize:])
+}
+
+// TestNonceBindingSealer_InnerUnsealError verifies that errors from the inner
+// sealer are propagated.
+func TestNonceBindingSealer_InnerUnsealError(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	_, err = sealer.UnsealFromFile("/nonexistent/path/file.sealed")
+	require.Error(t, err)
+}
+
+// TestNewNonceBindingSealer_InvalidNonceLength verifies that nonces with wrong
+// length are rejected.
+func TestNewNonceBindingSealer_InvalidNonceLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		nonce []byte
+	}{
+		{"empty", []byte{}},
+		{"too short", make([]byte, 16)},
+		{"too long", make([]byte, 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewNonceBindingSealer(plaintextSealer{}, tt.nonce)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "session nonce must be")
+		})
+	}
+}
+
+// TestNonceBindingSealer_ImplementsSealer verifies that NonceBindingSealer
+// satisfies the Sealer interface at compile time.
+func TestNonceBindingSealer_ImplementsSealer(t *testing.T) {
+	t.Parallel()
+
+	nonce := make([]byte, SessionNonceSize)
+	sealer, err := NewNonceBindingSealer(plaintextSealer{}, nonce)
+	require.NoError(t, err)
+
+	var _ Sealer = sealer
+}


### PR DESCRIPTION
## Summary

- After DKG registration, prevent the light client from falling back to `config.toml` when the sealed DB is missing or expired. The kernel now checks for existing `dist_key_share.sealed` files and refuses to start if sealed light client state is unavailable, requiring re-registration to resume.
- In `fallbackToConfigTrustedBlock`, move the check before `ClearTrustedState` to avoid irreversibly destroying valid DB state.
- Enforce `TDH2Verify` result in `PartialDecryptTDH2` — previously the verification result was logged but not acted upon.
- Add Light Client Recovery section to README documenting the initialization strategy, recovery procedure, and operational guidance.