### PR TITLE
feat(dkg): report rejected items in Process{Deals,Responses,Justification}

### DIFF
--- a/proto/kernel.proto
+++ b/proto/kernel.proto
@@ -104,6 +104,8 @@ message ProcessDealsResponse {
   bytes code_commitment = 1 [json_name = "code_commitment"];
   uint32 round = 2 [json_name = "round"];
   repeated Response responses = 3 [json_name = "responses"];
+  // Deals the kernel rejected; the client may retry these.
+  repeated Deal rejected_deals = 4 [json_name = "rejected_deals"];
 }
 
 message ProcessResponsesRequest {
@@ -115,6 +117,8 @@ message ProcessResponsesRequest {
 
 message ProcessResponsesResponse {
   repeated Justification justifications = 1 [json_name = "justifications"];
+  // Responses the kernel rejected; the client may retry these.
+  repeated Response rejected_responses = 2 [json_name = "rejected_responses"];
 }
 
 // ProcessJustificationRequest is sent to TEE to process valid justifications
@@ -127,7 +131,10 @@ message ProcessJustificationRequest {
 }
 
 // ProcessJustificationResponse is returned from TEE after processing justifications.
-message ProcessJustificationResponse {}
+message ProcessJustificationResponse {
+  // Justifications the kernel rejected; the client may retry these.
+  repeated Justification rejected_justifications = 1 [json_name = "rejected_justifications"];
+}
 
 message FinalizeDKGRequest {
   bytes code_commitment = 1 [json_name = "code_commitment"];

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -15,6 +16,25 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// isAlreadyProcessedErr returns true when err indicates the cached
+// DistKeyGenerator has already absorbed the artifact on a prior call. The
+// kernel silently skips these so the CL doesn't retry forever.
+//
+// NOTE: kyber v4.0.0-pre2 does NOT expose these as exported sentinels —
+// errDealAlreadyProcessed is package-private, and the other two are inline
+// errors.New(...). String matching is the only option. Re-validate the three
+// substrings below whenever go.dedis.ch/kyber is upgraded; if kyber starts
+// exporting sentinels, switch to errors.Is.
+func isAlreadyProcessedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "verifier already received a deal") ||
+		strings.Contains(msg, "already existing response from same origin") ||
+		strings.Contains(msg, "justification received for an approval")
+}
 
 // ProcessDeals process the deals. It is assumed that the deal has been correctly delivered to the corresponding recipient index.
 func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest) (*pb.ProcessDealsResponse, error) {
@@ -48,9 +68,16 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		return nil, status.Errorf(codes.Internal, "failed to get or load roundContext")
 	}
 
-	// Load DKG state from cache or rebuild from state
-	var distKeyGen *dkg.DistKeyGenerator
+	// dealerCount upper-bounds Deal.Index. Non-resharing has a single
+	// committee acting as dealers; resharing dealers are members of the
+	// PRIOR active committee (kyber's c.OldNodes inside the next-DKG).
+	var (
+		distKeyGen  *dkg.DistKeyGenerator
+		dealerCount int
+	)
 	if !req.GetIsResharing() {
+		dealerCount = len(rc.SortedPubKeys)
+
 		distKeyGen, err = s.GetInitDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
 		if err != nil {
 			log.Errorf("failed to load or rebuild initial distributed key generator: %v", err)
@@ -58,6 +85,18 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 			return nil, status.Errorf(codes.Internal, "failed to load or rebuild initial distributed key generator")
 		}
 	} else {
+		latest, err := s.QueryClient.GetLatestActiveDKGNetwork(context.Background())
+		if err != nil {
+			log.Errorf("failed to get the latest active round of DKG: %v", err)
+
+			return nil, status.Errorf(codes.Internal, "failed to get the latest active round of DKG")
+		}
+		if latest == nil || latest.GetTotal() == 0 {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"resharing requires an active prior DKG network")
+		}
+		dealerCount = int(latest.GetTotal())
+
 		distKeyGen, err = s.GetResharingNextDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
 		if err != nil {
 			log.Errorf("failed to load or rebuild the distributed key generator for resharing: %v", err)
@@ -67,18 +106,46 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 	}
 
 	var (
-		pbResps []*pb.Response
-		deals   []dkg.Deal
+		pbResps  []*pb.Response
+		deals    []dkg.Deal
+		rejected []*pb.Deal
 	)
 	for _, d := range req.GetDeals() {
 		deal := types.ConvertToDeal(d)
+
+		// Defence in depth: bounds-check the dealer index before kyber.
+		// kyber's ProcessDeal also rejects out-of-range indices, but a
+		// pre-check keeps the error path symmetric with the other two
+		// handlers and avoids exercising kyber's internal lookup tables
+		// with attacker-chosen indices.
+		if int(deal.Index) >= dealerCount {
+			rejected = append(rejected, d)
+
+			continue
+		}
+
 		resp, err := distKeyGen.ProcessDeal(deal)
 		if err != nil {
+			// Idempotent re-submission: the cached DistKeyGenerator has already
+			// absorbed this deal. Silent skip — do NOT include in rejected_deals
+			// so the client does not retry an artifact kyber will keep rejecting.
+			if isAlreadyProcessedErr(err) {
+				log.WithFields(log.Fields{
+					"round":           req.GetRound(),
+					"code_commitment": codeCommitmentHex,
+					"sender_index":    deal.Index,
+				}).Debugf("deal already stored on cached generator; skipping silently: %v", err)
+
+				continue
+			}
+
 			log.WithFields(log.Fields{
 				"round":           req.GetRound(),
 				"code_commitment": codeCommitmentHex,
 				"sender_index":    deal.Index,
 			}).Errorf("failed to process the deal: %v", err)
+
+			rejected = append(rejected, d)
 
 			continue
 		}
@@ -88,24 +155,26 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		deals = append(deals, *deal)
 	}
 
-	// Reject the request if every submitted deal failed processing.
-	if len(deals) == 0 {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"all %d submitted deals were rejected", len(req.GetDeals()))
+	if len(deals) > 0 {
+		if err := s.DKGStore.AddDeals(codeCommitmentHex, req.GetRound(), deals); err != nil {
+			log.Errorf("failed to add deals to the DKG state: %v", err)
+
+			return nil, status.Errorf(codes.Internal, "failed to add deals to the DKG state")
+		}
 	}
 
-	if err := s.DKGStore.AddDeals(codeCommitmentHex, req.GetRound(), deals); err != nil {
-		log.Errorf("failed to add deals to the DKG state: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to add deals to the DKG state")
-	}
-
-	log.Info("All deals have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"processed":       len(deals),
+		"rejected":        len(rejected),
+	}).Info("Processed deals")
 
 	return &pb.ProcessDealsResponse{
 		CodeCommitment: req.GetCodeCommitment(),
 		Round:          req.GetRound(),
 		Responses:      pbResps,
+		RejectedDeals:  rejected,
 	}, nil
 }
 

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -17,23 +17,45 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// errKyberDealAlreadyProcessed, errKyberResponseAlreadyExists and
+// errKyberJustificationOnApproval mirror the idempotent-error strings kyber
+// returns when the cached DistKeyGenerator has already absorbed an artifact
+// on a prior call. They are kept as locally-defined sentinels purely to
+// centralise the strings and document the source — see the NOTE on
+// isAlreadyProcessedErr for why we still match by substring rather than
+// errors.Is.
+//
+// Source: go.dedis.ch/kyber/v4@v4.0.0-pre2/share/vss/pedersen/vss.go
+//   - line 552: var errDealAlreadyProcessed (package-private)
+//   - line 639: errors.New("vss: justification received for an approval")
+//   - line 656: errors.New("vss: already existing response from same origin")
+var (
+	errKyberDealAlreadyProcessed    = errors.New("vss: verifier already received a deal")
+	errKyberResponseAlreadyExists   = errors.New("vss: already existing response from same origin")
+	errKyberJustificationOnApproval = errors.New("vss: justification received for an approval")
+)
+
 // isAlreadyProcessedErr returns true when err indicates the cached
 // DistKeyGenerator has already absorbed the artifact on a prior call. The
 // kernel silently skips these so the CL doesn't retry forever.
 //
 // NOTE: kyber v4.0.0-pre2 does NOT expose these as exported sentinels —
 // errDealAlreadyProcessed is package-private, and the other two are inline
-// errors.New(...). String matching is the only option. Re-validate the three
-// substrings below whenever go.dedis.ch/kyber is upgraded; if kyber starts
-// exporting sentinels, switch to errors.Is.
+// errors.New(...) created on every call. errors.Is therefore cannot match
+// any of the three (no exported reference for the first; non-sentinel for
+// the others) and kyber does not wrap with %w, so chain-unwrap also fails.
+// String matching is the only option today. If a future kyber release starts
+// exporting these as sentinels and wrapping them with %w, switch to
+// errors.Is against the kyber-exported values and remove the local sentinels
+// above.
 func isAlreadyProcessedErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "verifier already received a deal") ||
-		strings.Contains(msg, "already existing response from same origin") ||
-		strings.Contains(msg, "justification received for an approval")
+	return strings.Contains(msg, errKyberDealAlreadyProcessed.Error()) ||
+		strings.Contains(msg, errKyberResponseAlreadyExists.Error()) ||
+		strings.Contains(msg, errKyberJustificationOnApproval.Error())
 }
 
 // ProcessDeals process the deals. It is assumed that the deal has been correctly delivered to the corresponding recipient index.

--- a/service/dkg_process_deals_test.go
+++ b/service/dkg_process_deals_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,4 +157,55 @@ func TestValidateProcessDealsRequest_TableDriven(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIsAlreadyProcessedErr pins the kyber v4.0.0-pre2 idempotent-error
+// strings exactly so that a kyber upgrade renaming any of them fails this
+// test loudly. See the NOTE on isAlreadyProcessedErr for upgrade procedure.
+func TestIsAlreadyProcessedErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"verifier-already-deal", errDealAlreadyProcessedVerbatim(), true},
+		{"already-existing-response", errAlreadyExistingResponseVerbatim(), true},
+		{"justification-on-approval", errJustificationOnApprovalVerbatim(), true},
+		{"case-insensitive", errors.New("VSS: ALREADY EXISTING RESPONSE FROM SAME ORIGIN"), true},
+		{"wrapped-once", errWrap(errDealAlreadyProcessedVerbatim()), true},
+		{"unrelated-error", errors.New("dkg: dist deal out of bounds index"), false},
+		{"nil", nil, false},
+		{"plain-non-match", errors.New("network unreachable"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isAlreadyProcessedErr(tc.err))
+		})
+	}
+}
+
+// The next three helpers reproduce the EXACT kyber v4.0.0-pre2 error strings
+// (lifted from share/vss/pedersen/vss.go lines 552, 656, 639). If a kyber
+// upgrade changes the wording, the corresponding TestIsAlreadyProcessedErr
+// case fails and points at the substring that needs updating.
+func errDealAlreadyProcessedVerbatim() error {
+	return errors.New("vss: verifier already received a deal")
+}
+
+func errAlreadyExistingResponseVerbatim() error {
+	return errors.New("vss: already existing response from same origin")
+}
+
+func errJustificationOnApprovalVerbatim() error {
+	return errors.New("vss: justification received for an approval")
+}
+
+// errWrap returns an error that wraps the input — used to verify
+// isAlreadyProcessedErr handles wrapped errors via fmt.Errorf "%w".
+func errWrap(inner error) error {
+	return fmt.Errorf("kernel: %w", inner)
 }

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -50,11 +50,20 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 		return nil, status.Errorf(codes.Internal, "failed to get or load roundContext")
 	}
 
-	// Get the appropriate DistKeyGenerator(s) based on whether this is a resharing round.
-	// For resharing, justifications must be processed through both prev and next DKGs
-	// (same pattern as ProcessResponses).
+	// Bounds-check references for the per-item loop:
+	//   dealerCount    — upper bound for outer Justification.Index (the dealer).
+	//   recipientCount — upper bound for inner VssJustification.Index
+	//                    (the recipient of the original deal).
+	// Non-resharing rounds have a single committee acting as both. In
+	// resharing, dealers live in the OLD committee and recipients live
+	// in the NEW committee.
+	var dealerCount, recipientCount int
+
 	var distKeyGens []*dkg.DistKeyGenerator
 	if !req.GetIsResharing() {
+		dealerCount = len(rc.SortedPubKeys)
+		recipientCount = len(rc.SortedPubKeys)
+
 		distKeyGen, err := s.GetInitDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
 		if err != nil {
 			log.Errorf("failed to load or rebuild initial distributed key generator: %v", err)
@@ -69,6 +78,15 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 
 			return nil, status.Errorf(codes.Internal, "failed to get the latest active round of DKG")
 		}
+		// Defence in depth against a future regression that returns
+		// (nil, nil) on an uninitialised state.
+		if latest == nil || latest.GetTotal() == 0 {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"resharing requires an active prior DKG network")
+		}
+
+		dealerCount = int(latest.GetTotal())   // OLD committee
+		recipientCount = len(rc.SortedPubKeys) // NEW committee
 
 		prevDistKeyGen, err := s.GetResharingPrevDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys, latest)
 		if err != nil {
@@ -85,9 +103,22 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 		}
 	}
 
-	// Process each justification through all DKG instances, continuing on
-	// individual failures (matches ProcessDeals/ProcessResponses pattern).
-	var processed []dkg.Justification
+	// Fail loudly if no DistKeyGenerator is available (see ProcessResponses for
+	// the same guard — otherwise the per-item loop silently succeeds).
+	if len(distKeyGens) == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"no DistKeyGenerator available for this round (node not a member of the required committee(s))")
+	}
+
+	// Process each justification. A justification is considered rejected iff
+	// proto conversion fails, the dealer/recipient index is out of bounds, OR
+	// every configured DistKeyGenerator rejects it with a non-idempotent error.
+	// If every generator returns an idempotent "already processed" error the
+	// justification is silently skipped (NOT added to rejected_justifications).
+	var (
+		justs    []dkg.Justification
+		rejected []*pb.Justification
+	)
 	for _, j := range req.GetJustifications() {
 		justification, err := types.ConvertToJustification(j)
 		if err != nil {
@@ -96,9 +127,26 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 				"code_commitment": codeCommitmentHex,
 			}).Errorf("failed to convert justification from proto: %v", err)
 
+			rejected = append(rejected, j)
+
 			continue
 		}
 
+		// Defence in depth: bounds-check both the dealer and the recipient
+		// index before kyber. In resharing the dealer is an old-committee
+		// member (range [0, dealerCount)) and the recipient is a new-committee
+		// member (range [0, recipientCount)).
+		if int(justification.Index) >= dealerCount ||
+			int(j.GetVssJustification().GetIndex()) >= recipientCount {
+			rejected = append(rejected, j)
+
+			continue
+		}
+
+		// processed: at least one DistKeyGenerator applied this justification
+		// (real success or idempotent re-submission). Reject only when
+		// EVERY generator returned a real (non-idempotent) error.
+		processed := false
 		for _, distKeyGen := range distKeyGens {
 			if err := distKeyGen.ProcessJustification(justification); err != nil {
 				log.WithFields(log.Fields{
@@ -107,11 +155,22 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 					"dealer_index":    justification.Index,
 				}).Errorf("failed to process justification: %v", err)
 
+				if isAlreadyProcessedErr(err) {
+					processed = true
+				}
+
 				continue
 			}
+			processed = true
 		}
 
-		processed = append(processed, *justification)
+		if !processed {
+			rejected = append(rejected, j)
+
+			continue
+		}
+
+		justs = append(justs, *justification)
 
 		log.WithFields(log.Fields{
 			"round":           req.GetRound(),
@@ -121,17 +180,24 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 	}
 
 	// Persist successfully processed justifications for recovery replay
-	if len(processed) > 0 {
-		if err := s.DKGStore.AddJustifications(codeCommitmentHex, req.GetRound(), processed); err != nil {
+	if len(justs) > 0 {
+		if err := s.DKGStore.AddJustifications(codeCommitmentHex, req.GetRound(), justs); err != nil {
 			log.Errorf("failed to add justifications to the DKG state: %v", err)
 
 			return nil, status.Errorf(codes.Internal, "failed to add justifications to the DKG state")
 		}
 	}
 
-	log.Info("All justifications have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"processed":       len(justs),
+		"rejected":        len(rejected),
+	}).Info("Processed justifications")
 
-	return &pb.ProcessJustificationResponse{}, nil
+	return &pb.ProcessJustificationResponse{
+		RejectedJustifications: rejected,
+	}, nil
 }
 
 func validateProcessJustificationRequest(req *pb.ProcessJustificationRequest) error {

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -143,10 +143,21 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 			continue
 		}
 
-		// processed: at least one DistKeyGenerator applied this justification
-		// (real success or idempotent re-submission). Reject only when
-		// EVERY generator returned a real (non-idempotent) error.
-		processed := false
+		// applied:          at least one DistKeyGenerator successfully
+		//                   absorbed this justification on THIS call. Only
+		//                   then is it safe to persist for replay.
+		// alreadyProcessed: at least one DistKeyGenerator reported the
+		//                   justification was absorbed on a PRIOR call
+		//                   (idempotent re-submission). Silently skip — do
+		//                   not reject, do not persist. Persisting a
+		//                   duplicate would cause replayMessages (which
+		//                   does NOT suppress duplicate justification
+		//                   errors, unlike responses) to fail fatally on
+		//                   restart.
+		// Reject only when EVERY generator returned a real (non-idempotent)
+		// error.
+		applied := false
+		alreadyProcessed := false
 		for _, distKeyGen := range distKeyGens {
 			if err := distKeyGen.ProcessJustification(justification); err != nil {
 				log.WithFields(log.Fields{
@@ -156,16 +167,28 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 				}).Errorf("failed to process justification: %v", err)
 
 				if isAlreadyProcessedErr(err) {
-					processed = true
+					alreadyProcessed = true
 				}
 
 				continue
 			}
-			processed = true
+			applied = true
 		}
 
-		if !processed {
+		if !applied && !alreadyProcessed {
 			rejected = append(rejected, j)
+
+			continue
+		}
+
+		if !applied {
+			// Idempotent re-submission only — do not persist. Logging at
+			// debug to mirror the dealing handler's silent-skip semantics.
+			log.WithFields(log.Fields{
+				"round":           req.GetRound(),
+				"code_commitment": codeCommitmentHex,
+				"dealer_index":    justification.Index,
+			}).Debug("justification already stored on cached generator; skipping silently")
 
 			continue
 		}

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -155,11 +155,15 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 		for _, distKeyGen := range distKeyGens {
 			j, err := distKeyGen.ProcessResponse(resp)
 			if err != nil {
+				// Log only indices to match the dealing/justification handlers'
+				// hygiene; avoids dumping the full VSSResponse struct into logs
+				// in case future kyber/proto evolution adds fields not safe to
+				// expose verbatim.
 				log.WithFields(log.Fields{
-					"round":           req.GetRound(),
-					"code_commitment": codeCommitmentHex,
-					"index":           response.GetIndex(),
-					"vss_response":    response.GetVssResponse(),
+					"round":            req.GetRound(),
+					"code_commitment":  codeCommitmentHex,
+					"dealer_index":     response.GetIndex(),
+					"complainer_index": response.GetVssResponse().GetIndex(),
 				}).Errorf("failed to process the response: %v", err)
 
 				if isAlreadyProcessedErr(err) {

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -177,12 +177,22 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 
 			justification, convErr := types.ConvertToJustificationProto(j)
 			if convErr != nil {
-				// Log only the index to avoid leaking sensitive data (e.g., SecShare in PlainDeal).
+				// kyber already absorbed `resp`; retry would hit the idempotent
+				// guard (j == nil) and never re-derive the justification.
+				// Putting `response` in rejected_responses would mislead the CL
+				// into retrying a permanently-lost artifact, and failing the
+				// whole RPC would also discard valid justifications already
+				// converted in this batch. Drop only this justification — the
+				// response itself is still added to resps below so kyber's
+				// in-memory state and DKGStore stay consistent.
+				// (Effectively unreachable on Ed25519 — kept for future suite changes.)
+				// Log only the index to avoid leaking SecShare from PlainDeal.
 				log.WithFields(log.Fields{
+					"round":               req.GetRound(),
+					"code_commitment":     codeCommitmentHex,
 					"justification_index": j.Index,
-				}).Errorf("failed to convert to justification proto: %v", convErr)
-
-				rejected = append(rejected, response)
+				}).Errorf("failed to convert generated justification to proto; "+
+					"justification dropped: %v", convErr)
 
 				continue
 			}

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -47,8 +47,20 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 		return nil, status.Errorf(codes.Internal, "failed to get or load roundContext")
 	}
 
+	// Bounds-check references for the per-item loop:
+	//   dealerCount     — upper bound for outer Response.Index (the dealer).
+	//   complainerCount — upper bound for inner VssResponse.Index (the
+	//                     responder/complainer).
+	// Non-resharing rounds have a single committee acting as both. In
+	// resharing, dealers live in the OLD committee and complainers live
+	// in the NEW committee, so the bounds diverge.
+	var dealerCount, complainerCount int
+
 	var distKeyGens []*dkg.DistKeyGenerator
 	if !req.GetIsResharing() {
+		dealerCount = len(rc.SortedPubKeys)
+		complainerCount = len(rc.SortedPubKeys)
+
 		distKeyGen, err := s.GetInitDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
 		if err != nil {
 			log.Errorf("failed to load or rebuild initial distributed key generator: %v", err)
@@ -63,6 +75,16 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 
 			return nil, status.Errorf(codes.Internal, "failed to get the latest active round of DKG")
 		}
+		// Defence in depth against a future regression in
+		// GetLatestActiveDKGNetwork that returns (nil, nil) on an
+		// uninitialised state.
+		if latest == nil || latest.GetTotal() == 0 {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"resharing requires an active prior DKG network")
+		}
+
+		dealerCount = int(latest.GetTotal())    // OLD committee
+		complainerCount = len(rc.SortedPubKeys) // NEW committee
 
 		prevDistKeyGen, err := s.GetResharingPrevDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys, latest)
 		if err != nil {
@@ -79,17 +101,60 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 		}
 	}
 
-	// Process the responses
+	// Fail loudly if no DistKeyGenerator is available — without this guard
+	// the per-item loop would silently treat every input as processed
+	// (the empty for-range exits without setting any flags).
+	if len(distKeyGens) == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"no DistKeyGenerator available for this round (node not a member of the required committee(s))")
+	}
+
+	// Process the responses. A response is considered rejected iff it fails
+	// against EVERY configured DistKeyGenerator with a non-idempotent error.
+	// For resharing (prev+next), accepted-by-any wins. If every generator
+	// returns an idempotent "already existing" error the response is silently
+	// skipped (NOT added to rejected_responses) so the client doesn't retry
+	// something kyber has already absorbed.
+	//
+	// rejected may contain duplicates of the same response when both a
+	// proto-conversion failure AND a generator failure happen on the same
+	// item; the CL deduplicates via a per-batch map keyed by (Index, inner
+	// Index) so we don't bother deduping here.
 	var (
 		justifications []*pb.Justification
 		resps          []dkg.Response
+		rejected       []*pb.Response
 	)
 	for _, response := range req.GetResponses() {
 		resp := types.ConvertToVSSResp(response)
+
+		// Defence in depth: bounds-check the dealer AND complainer indices
+		// before kyber. processResharingResponse lazily inserts aggregators
+		// keyed by resp.Index without validation, so an out-of-range index
+		// could grow the aggregators map inside the enclave. In resharing,
+		// dealers are old-committee members and complainers are new-committee
+		// members.
+		if int(resp.Index) >= dealerCount {
+			rejected = append(rejected, response)
+
+			continue
+		}
+		if resp.Response != nil && int(resp.Response.Index) >= complainerCount {
+			rejected = append(rejected, response)
+
+			continue
+		}
+
+		// processed: at least one DistKeyGenerator applied the response (real
+		// success or idempotent re-submission). In resharing (prev + next),
+		// only one generator typically owns a given response — the others
+		// may return real errors ("unknown dealer" etc.) without indicating
+		// rejection. Reject only when EVERY generator returned a real
+		// (non-idempotent) error.
+		processed := false
 		for _, distKeyGen := range distKeyGens {
 			j, err := distKeyGen.ProcessResponse(resp)
 			if err != nil {
-				// skip the responses
 				log.WithFields(log.Fields{
 					"round":           req.GetRound(),
 					"code_commitment": codeCommitmentHex,
@@ -97,37 +162,61 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 					"vss_response":    response.GetVssResponse(),
 				}).Errorf("failed to process the response: %v", err)
 
+				if isAlreadyProcessedErr(err) {
+					processed = true
+				}
+
 				continue
 			}
 
-			if j != nil {
-				justification, err := types.ConvertToJustificationProto(j)
-				if err != nil {
-					// Log only the index to avoid leaking sensitive data (e.g., SecShare in PlainDeal).
-					log.WithFields(log.Fields{
-						"justification_index": j.Index,
-					}).Errorf("failed to convert to justification proto: %v", err)
+			processed = true
 
-					return nil, status.Errorf(codes.Internal, "failed to convert to justification proto")
-				}
-
-				justifications = append(justifications, justification)
+			if j == nil {
+				continue
 			}
+
+			justification, convErr := types.ConvertToJustificationProto(j)
+			if convErr != nil {
+				// Log only the index to avoid leaking sensitive data (e.g., SecShare in PlainDeal).
+				log.WithFields(log.Fields{
+					"justification_index": j.Index,
+				}).Errorf("failed to convert to justification proto: %v", convErr)
+
+				rejected = append(rejected, response)
+
+				continue
+			}
+
+			justifications = append(justifications, justification)
+		}
+
+		if !processed {
+			rejected = append(rejected, response)
+
+			continue
 		}
 
 		resps = append(resps, *resp)
 	}
 
-	if err := s.DKGStore.AddResponses(codeCommitmentHex, req.GetRound(), resps); err != nil {
-		log.Errorf("failed to add responses to the DKG state: %v", err)
+	if len(resps) > 0 {
+		if err := s.DKGStore.AddResponses(codeCommitmentHex, req.GetRound(), resps); err != nil {
+			log.Errorf("failed to add responses to the DKG state: %v", err)
 
-		return nil, status.Errorf(codes.Internal, "failed to add responses to the DKG state")
+			return nil, status.Errorf(codes.Internal, "failed to add responses to the DKG state")
+		}
 	}
 
-	log.Info("All responses have been processed", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"processed":       len(resps),
+		"rejected":        len(rejected),
+	}).Info("Processed responses")
 
 	return &pb.ProcessResponsesResponse{
-		Justifications: justifications,
+		Justifications:    justifications,
+		RejectedResponses: rejected,
 	}, nil
 }
 

--- a/service/kyber_idempotent_integration_test.go
+++ b/service/kyber_idempotent_integration_test.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/group/edwards25519"
+	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+)
+
+// TestIsAlreadyProcessedErr_AgainstRealKyber drives a small live DKG with
+// real kyber DistKeyGenerators and replays the same artifact twice to force
+// kyber's idempotent-error paths. It asserts that isAlreadyProcessedErr
+// classifies each real error correctly.
+//
+// Why this exists: TestIsAlreadyProcessedErr (in dkg_process_deals_test.go)
+// pins the *literal* strings the matcher accepts. That catches matcher drift
+// but NOT kyber drift — if a future kyber bump rewords any of these errors,
+// the unit test still passes while production silently misclassifies real
+// idempotent re-submissions as `rejected_*`. This test fails CI on kyber
+// drift. Re-run after every go.dedis.ch/kyber bump.
+//
+// Justification idempotent path is intentionally omitted here: triggering
+// it requires fabricating a complaint and processing the resulting
+// justification twice, which adds a lot of fragile setup for marginal
+// extra coverage. The literal-string assertion in TestIsAlreadyProcessedErr
+// already pins that wording (`"vss: justification received for an
+// approval"`). If kyber renames it, that test fails first.
+func TestIsAlreadyProcessedErr_AgainstRealKyber(t *testing.T) {
+	t.Parallel()
+
+	const (
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	// Generate longterm key pairs and the corresponding public-key list.
+	longterms := make([]kyber.Scalar, n)
+	pubs := make([]kyber.Point, n)
+	for i := range n {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	// One DistKeyGenerator per party.
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := range n {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoErrorf(t, err, "NewDistKeyGenerator party %d", i)
+		gens[i] = g
+	}
+
+	// Party 0 issues deals for every other party.
+	deals, err := gens[0].Deals()
+	require.NoError(t, err)
+	require.NotEmpty(t, deals)
+
+	t.Run("deal-double-submit-yields-already-processed", func(t *testing.T) {
+		t.Parallel()
+
+		// Pick deal addressed to party 1.
+		dealForP1, ok := deals[1]
+		require.True(t, ok, "expected a deal for party 1")
+
+		// Use a fresh generator for party 1 so this subtest does not race
+		// with the response path below.
+		g1, err := dkg.NewDistKeyGenerator(suite, longterms[1], pubs, threshold)
+		require.NoError(t, err)
+
+		// First ProcessDeal must succeed.
+		_, err = g1.ProcessDeal(dealForP1)
+		require.NoError(t, err)
+
+		// Second ProcessDeal triggers kyber's
+		//   var errDealAlreadyProcessed = errors.New("vss: verifier already received a deal")
+		// (share/vss/pedersen/vss.go:552).
+		_, err = g1.ProcessDeal(dealForP1)
+		require.Error(t, err, "second ProcessDeal must fail")
+		require.True(t, isAlreadyProcessedErr(err),
+			"isAlreadyProcessedErr must classify kyber's deal-already-processed error: %v", err)
+	})
+
+	t.Run("response-double-submit-yields-already-existing", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a fresh dealer (party 0) so the response-side state is
+		// independent of the deal subtest.
+		dealer, err := dkg.NewDistKeyGenerator(suite, longterms[0], pubs, threshold)
+		require.NoError(t, err)
+		dealerDeals, err := dealer.Deals()
+		require.NoError(t, err)
+
+		// Party 1 produces an approval response to party 0's deal.
+		responder, err := dkg.NewDistKeyGenerator(suite, longterms[1], pubs, threshold)
+		require.NoError(t, err)
+		resp, err := responder.ProcessDeal(dealerDeals[1])
+		require.NoError(t, err)
+
+		// Dealer applies the response once — must succeed.
+		_, err = dealer.ProcessResponse(resp)
+		require.NoError(t, err)
+
+		// Second ProcessResponse triggers kyber's
+		//   errors.New("vss: already existing response from same origin")
+		// (share/vss/pedersen/vss.go:656).
+		_, err = dealer.ProcessResponse(resp)
+		require.Error(t, err, "second ProcessResponse must fail")
+		require.True(t, isAlreadyProcessedErr(err),
+			"isAlreadyProcessedErr must classify kyber's response-already-existing error: %v", err)
+	})
+}

--- a/types/pb/v0/kernel.pb.go
+++ b/types/pb/v0/kernel.pb.go
@@ -796,8 +796,10 @@ type ProcessDealsResponse struct {
 	CodeCommitment []byte                 `protobuf:"bytes,1,opt,name=code_commitment,proto3" json:"code_commitment,omitempty"`
 	Round          uint32                 `protobuf:"varint,2,opt,name=round,proto3" json:"round,omitempty"`
 	Responses      []*Response            `protobuf:"bytes,3,rep,name=responses,proto3" json:"responses,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Deals the kernel rejected; the client may retry these.
+	RejectedDeals []*Deal `protobuf:"bytes,4,rep,name=rejected_deals,proto3" json:"rejected_deals,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ProcessDealsResponse) Reset() {
@@ -847,6 +849,13 @@ func (x *ProcessDealsResponse) GetRound() uint32 {
 func (x *ProcessDealsResponse) GetResponses() []*Response {
 	if x != nil {
 		return x.Responses
+	}
+	return nil
+}
+
+func (x *ProcessDealsResponse) GetRejectedDeals() []*Deal {
+	if x != nil {
+		return x.RejectedDeals
 	}
 	return nil
 }
@@ -922,8 +931,10 @@ func (x *ProcessResponsesRequest) GetIsResharing() bool {
 type ProcessResponsesResponse struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Justifications []*Justification       `protobuf:"bytes,1,rep,name=justifications,proto3" json:"justifications,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Responses the kernel rejected; the client may retry these.
+	RejectedResponses []*Response `protobuf:"bytes,2,rep,name=rejected_responses,proto3" json:"rejected_responses,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ProcessResponsesResponse) Reset() {
@@ -959,6 +970,13 @@ func (*ProcessResponsesResponse) Descriptor() ([]byte, []int) {
 func (x *ProcessResponsesResponse) GetJustifications() []*Justification {
 	if x != nil {
 		return x.Justifications
+	}
+	return nil
+}
+
+func (x *ProcessResponsesResponse) GetRejectedResponses() []*Response {
+	if x != nil {
+		return x.RejectedResponses
 	}
 	return nil
 }
@@ -1035,9 +1053,11 @@ func (x *ProcessJustificationRequest) GetIsResharing() bool {
 
 // ProcessJustificationResponse is returned from TEE after processing justifications.
 type ProcessJustificationResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Justifications the kernel rejected; the client may retry these.
+	RejectedJustifications []*Justification `protobuf:"bytes,1,rep,name=rejected_justifications,proto3" json:"rejected_justifications,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ProcessJustificationResponse) Reset() {
@@ -1068,6 +1088,13 @@ func (x *ProcessJustificationResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ProcessJustificationResponse.ProtoReflect.Descriptor instead.
 func (*ProcessJustificationResponse) Descriptor() ([]byte, []int) {
 	return file_kernel_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ProcessJustificationResponse) GetRejectedJustifications() []*Justification {
+	if x != nil {
+		return x.RejectedJustifications
+	}
+	return nil
 }
 
 type FinalizeDKGRequest struct {
@@ -1435,24 +1462,27 @@ const file_kernel_proto_rawDesc = "" +
 	"\x0fcode_commitment\x18\x01 \x01(\fR\x0fcode_commitment\x12\x14\n" +
 	"\x05round\x18\x02 \x01(\rR\x05round\x12.\n" +
 	"\x05deals\x18\x03 \x03(\v2\x18.story.dkg.v1.types.DealR\x05deals\x12\"\n" +
-	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"\x92\x01\n" +
+	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"\xd4\x01\n" +
 	"\x14ProcessDealsResponse\x12(\n" +
 	"\x0fcode_commitment\x18\x01 \x01(\fR\x0fcode_commitment\x12\x14\n" +
 	"\x05round\x18\x02 \x01(\rR\x05round\x12:\n" +
-	"\tresponses\x18\x03 \x03(\v2\x1c.story.dkg.v1.types.ResponseR\tresponses\"\xb9\x01\n" +
+	"\tresponses\x18\x03 \x03(\v2\x1c.story.dkg.v1.types.ResponseR\tresponses\x12@\n" +
+	"\x0erejected_deals\x18\x04 \x03(\v2\x18.story.dkg.v1.types.DealR\x0erejected_deals\"\xb9\x01\n" +
 	"\x17ProcessResponsesRequest\x12(\n" +
 	"\x0fcode_commitment\x18\x01 \x01(\fR\x0fcode_commitment\x12\x14\n" +
 	"\x05round\x18\x02 \x01(\rR\x05round\x12:\n" +
 	"\tresponses\x18\x03 \x03(\v2\x1c.story.dkg.v1.types.ResponseR\tresponses\x12\"\n" +
-	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"e\n" +
+	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"\xb3\x01\n" +
 	"\x18ProcessResponsesResponse\x12I\n" +
-	"\x0ejustifications\x18\x01 \x03(\v2!.story.dkg.v1.types.JustificationR\x0ejustifications\"\xcc\x01\n" +
+	"\x0ejustifications\x18\x01 \x03(\v2!.story.dkg.v1.types.JustificationR\x0ejustifications\x12L\n" +
+	"\x12rejected_responses\x18\x02 \x03(\v2\x1c.story.dkg.v1.types.ResponseR\x12rejected_responses\"\xcc\x01\n" +
 	"\x1bProcessJustificationRequest\x12(\n" +
 	"\x0fcode_commitment\x18\x01 \x01(\fR\x0fcode_commitment\x12\x14\n" +
 	"\x05round\x18\x02 \x01(\rR\x05round\x12I\n" +
 	"\x0ejustifications\x18\x03 \x03(\v2!.story.dkg.v1.types.JustificationR\x0ejustifications\x12\"\n" +
-	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"\x1e\n" +
-	"\x1cProcessJustificationResponse\"x\n" +
+	"\fis_resharing\x18\x04 \x01(\bR\fis_resharing\"{\n" +
+	"\x1cProcessJustificationResponse\x12[\n" +
+	"\x17rejected_justifications\x18\x01 \x03(\v2!.story.dkg.v1.types.JustificationR\x17rejected_justifications\"x\n" +
 	"\x12FinalizeDKGRequest\x12(\n" +
 	"\x0fcode_commitment\x18\x01 \x01(\fR\x0fcode_commitment\x12\x14\n" +
 	"\x05round\x18\x02 \x01(\rR\x05round\x12\"\n" +
@@ -1546,30 +1576,33 @@ var file_kernel_proto_depIdxs = []int32{
 	20, // 2: story.dkg.v1.types.GenerateDealsResponse.deals:type_name -> story.dkg.v1.types.Deal
 	20, // 3: story.dkg.v1.types.ProcessDealsRequest.deals:type_name -> story.dkg.v1.types.Deal
 	21, // 4: story.dkg.v1.types.ProcessDealsResponse.responses:type_name -> story.dkg.v1.types.Response
-	21, // 5: story.dkg.v1.types.ProcessResponsesRequest.responses:type_name -> story.dkg.v1.types.Response
-	22, // 6: story.dkg.v1.types.ProcessResponsesResponse.justifications:type_name -> story.dkg.v1.types.Justification
-	22, // 7: story.dkg.v1.types.ProcessJustificationRequest.justifications:type_name -> story.dkg.v1.types.Justification
-	2,  // 8: story.dkg.v1.types.KernelService.GetCodeCommitment:input_type -> story.dkg.v1.types.GetCodeCommitmentRequest
-	4,  // 9: story.dkg.v1.types.KernelService.GenerateAndSealKey:input_type -> story.dkg.v1.types.GenerateAndSealKeyRequest
-	8,  // 10: story.dkg.v1.types.KernelService.GenerateDeals:input_type -> story.dkg.v1.types.GenerateDealsRequest
-	10, // 11: story.dkg.v1.types.KernelService.ProcessDeals:input_type -> story.dkg.v1.types.ProcessDealsRequest
-	12, // 12: story.dkg.v1.types.KernelService.ProcessResponses:input_type -> story.dkg.v1.types.ProcessResponsesRequest
-	14, // 13: story.dkg.v1.types.KernelService.ProcessJustification:input_type -> story.dkg.v1.types.ProcessJustificationRequest
-	16, // 14: story.dkg.v1.types.KernelService.FinalizeDKG:input_type -> story.dkg.v1.types.FinalizeDKGRequest
-	18, // 15: story.dkg.v1.types.KernelService.PartialDecryptTDH2:input_type -> story.dkg.v1.types.PartialDecryptTDH2Request
-	3,  // 16: story.dkg.v1.types.KernelService.GetCodeCommitment:output_type -> story.dkg.v1.types.GetCodeCommitmentResponse
-	5,  // 17: story.dkg.v1.types.KernelService.GenerateAndSealKey:output_type -> story.dkg.v1.types.GenerateAndSealKeyResponse
-	9,  // 18: story.dkg.v1.types.KernelService.GenerateDeals:output_type -> story.dkg.v1.types.GenerateDealsResponse
-	11, // 19: story.dkg.v1.types.KernelService.ProcessDeals:output_type -> story.dkg.v1.types.ProcessDealsResponse
-	13, // 20: story.dkg.v1.types.KernelService.ProcessResponses:output_type -> story.dkg.v1.types.ProcessResponsesResponse
-	15, // 21: story.dkg.v1.types.KernelService.ProcessJustification:output_type -> story.dkg.v1.types.ProcessJustificationResponse
-	17, // 22: story.dkg.v1.types.KernelService.FinalizeDKG:output_type -> story.dkg.v1.types.FinalizeDKGResponse
-	19, // 23: story.dkg.v1.types.KernelService.PartialDecryptTDH2:output_type -> story.dkg.v1.types.PartialDecryptTDH2Response
-	16, // [16:24] is the sub-list for method output_type
-	8,  // [8:16] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	20, // 5: story.dkg.v1.types.ProcessDealsResponse.rejected_deals:type_name -> story.dkg.v1.types.Deal
+	21, // 6: story.dkg.v1.types.ProcessResponsesRequest.responses:type_name -> story.dkg.v1.types.Response
+	22, // 7: story.dkg.v1.types.ProcessResponsesResponse.justifications:type_name -> story.dkg.v1.types.Justification
+	21, // 8: story.dkg.v1.types.ProcessResponsesResponse.rejected_responses:type_name -> story.dkg.v1.types.Response
+	22, // 9: story.dkg.v1.types.ProcessJustificationRequest.justifications:type_name -> story.dkg.v1.types.Justification
+	22, // 10: story.dkg.v1.types.ProcessJustificationResponse.rejected_justifications:type_name -> story.dkg.v1.types.Justification
+	2,  // 11: story.dkg.v1.types.KernelService.GetCodeCommitment:input_type -> story.dkg.v1.types.GetCodeCommitmentRequest
+	4,  // 12: story.dkg.v1.types.KernelService.GenerateAndSealKey:input_type -> story.dkg.v1.types.GenerateAndSealKeyRequest
+	8,  // 13: story.dkg.v1.types.KernelService.GenerateDeals:input_type -> story.dkg.v1.types.GenerateDealsRequest
+	10, // 14: story.dkg.v1.types.KernelService.ProcessDeals:input_type -> story.dkg.v1.types.ProcessDealsRequest
+	12, // 15: story.dkg.v1.types.KernelService.ProcessResponses:input_type -> story.dkg.v1.types.ProcessResponsesRequest
+	14, // 16: story.dkg.v1.types.KernelService.ProcessJustification:input_type -> story.dkg.v1.types.ProcessJustificationRequest
+	16, // 17: story.dkg.v1.types.KernelService.FinalizeDKG:input_type -> story.dkg.v1.types.FinalizeDKGRequest
+	18, // 18: story.dkg.v1.types.KernelService.PartialDecryptTDH2:input_type -> story.dkg.v1.types.PartialDecryptTDH2Request
+	3,  // 19: story.dkg.v1.types.KernelService.GetCodeCommitment:output_type -> story.dkg.v1.types.GetCodeCommitmentResponse
+	5,  // 20: story.dkg.v1.types.KernelService.GenerateAndSealKey:output_type -> story.dkg.v1.types.GenerateAndSealKeyResponse
+	9,  // 21: story.dkg.v1.types.KernelService.GenerateDeals:output_type -> story.dkg.v1.types.GenerateDealsResponse
+	11, // 22: story.dkg.v1.types.KernelService.ProcessDeals:output_type -> story.dkg.v1.types.ProcessDealsResponse
+	13, // 23: story.dkg.v1.types.KernelService.ProcessResponses:output_type -> story.dkg.v1.types.ProcessResponsesResponse
+	15, // 24: story.dkg.v1.types.KernelService.ProcessJustification:output_type -> story.dkg.v1.types.ProcessJustificationResponse
+	17, // 25: story.dkg.v1.types.KernelService.FinalizeDKG:output_type -> story.dkg.v1.types.FinalizeDKGResponse
+	19, // 26: story.dkg.v1.types.KernelService.PartialDecryptTDH2:output_type -> story.dkg.v1.types.PartialDecryptTDH2Response
+	19, // [19:27] is the sub-list for method output_type
+	11, // [11:19] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_kernel_proto_init() }


### PR DESCRIPTION
## Summary
- Each `ProcessXResponse` now carries a typed `rejected_<type>` slice listing items the kernel could not absorb, so the CL can retry them individually instead of failing the whole batch.
- Idempotent re-submissions (kyber's `vss: verifier already received a deal`, `already existing response from same origin`, `justification received for an approval`) are silently skipped on the kernel side and never appear in `rejected_*` — prevents gossip duplicates from amplifying retry traffic.

## Compatibility
The new fields are appended at unused tags, so old CLs that don't decode them just see the legacy success/error behaviour. New CLs require this kernel to actually populate the fields.