### PR TITLE
chore: extend root CODEOWNERS with new reviewers + drop stale entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lucas2brh @wo-o @barry-peng-story
+* @lucas2brh @wo-o @barry-peng-story @0xHansLee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lucas2brh @wo-o @barry-peng-chao
+* @lucas2brh @wo-o @barry-peng-story

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @lucas2brh @wo-o @barry-peng-story @0xHansLee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lucas2brh @wo-o @barry-peng-chao

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @LeoHChen @jdubpark @limengformal @0xHansLee @ramtinms @stevemilk @yingyangxu2026 @lucas2brh @wo-o @barry-peng-story
+* @LeoHChen @jdubpark @0xHansLee @ramtinms @stevemilk @yingyangxu2026 @lucas2brh @wo-o @barry-peng-story
 
-/.github @wo-o @limengformal @jack-piplabs
+/.github @wo-o

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @LeoHChen @jdubpark @limengformal @0xHansLee @ramtinms @stevemilk @yingyangxu2026
+* @LeoHChen @jdubpark @limengformal @0xHansLee @ramtinms @stevemilk @yingyangxu2026 @lucas2brh @wo-o @barry-peng-story
 
 /.github @wo-o @limengformal @jack-piplabs


### PR DESCRIPTION
## Summary
- Append `@lucas2brh @wo-o @barry-peng-story` to the catch-all rule in the existing root `CODEOWNERS` so PRs auto-request review from this group too.
- Drop stale entries that GitHub flagged as unknown owners:
  - `@limengformal` — user exists but has no write access on this repo
  - `@jack-piplabs` — account does not exist (404)
- No change to `@LeoHChen @jdubpark @0xHansLee @ramtinms @stevemilk @yingyangxu2026`.

## Test plan
- [ ] After merge, open a follow-up PR and confirm GitHub auto-requests the new reviewers without raising CODEOWNERS errors