### PR TITLE
fix(service): wait for finalization stage before computing the participants root

### DIFF
--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -3,8 +3,10 @@ package service
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
@@ -17,6 +19,14 @@ import (
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	// finalizeStageRetryAttempts/Delay bound how long FinalizeDKG waits for the light
+	// client to reach the finalization stage. The light client refreshes every 3s, so a
+	// 2s interval observes the update promptly; 5 attempts (~10s) covers observed lag.
+	finalizeStageRetryAttempts = 5
+	finalizeStageRetryDelay    = 2 * time.Second
 )
 
 func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (*pb.FinalizeDKGResponse, error) {
@@ -120,12 +130,17 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 		return nil, status.Errorf(codes.Internal, "failed to marshal public coeffs")
 	}
 
-	// Calculate participants root from verified registrations
-	registrations, err := s.QueryClient.GetAllParticipantDKGRegistrations(context.Background(), codeCommitmentHex, req.GetRound())
+	// Calculate participants root from the post-invalidation participant set. The chain
+	// flips the round to the finalization stage, invalidates dealers that submitted no deal,
+	// and emits BeginDKGFinalization in the same block, so we must wait until the light
+	// client has observed that block before reading registrations. Otherwise a lagging
+	// trusted height may still report an invalidated dealer as VERIFIED, producing a
+	// participants root that disagrees with the set the chain agreed on.
+	registrations, err := s.waitForFinalizationRegistrations(codeCommitmentHex, req.GetRound())
 	if err != nil {
-		log.Errorf("failed to get verified DKG registrations: %v", err)
+		log.Errorf("failed to get finalization DKG registrations: %v", err)
 
-		return nil, status.Errorf(codes.Internal, "failed to get verified DKG registrations")
+		return nil, status.Errorf(codes.Internal, "failed to get finalization DKG registrations")
 	}
 
 	participantsRoot, err := calculateParticipantsRoot(registrations)
@@ -189,6 +204,37 @@ func validateFinalizeDKGRequest(req *pb.FinalizeDKGRequest) error {
 	}
 
 	return nil
+}
+
+// waitForFinalizationRegistrations blocks until the light client observes the round at the
+// finalization stage (or later), then returns the participant registrations read at that
+// height. Because missing-dealer invalidation happens in the same block that advances the
+// stage to finalization, waiting for that stage guarantees the returned set excludes any
+// invalidated dealer, so the kernel's participants root matches the chain's. It retries
+// while the light client still reports an earlier stage, returning ErrLightClientLag once
+// the retry budget is exhausted.
+func (s *DKGServer) waitForFinalizationRegistrations(codeCommitmentHex string, round uint32) ([]*pb.DKGRegistration, error) {
+	for attempt := range finalizeStageRetryAttempts {
+		network, err := s.QueryClient.GetDKGNetwork(context.Background(), codeCommitmentHex, round)
+		if err != nil {
+			return nil, err
+		}
+
+		if network.GetStage() >= pb.DKGStage_DKG_STAGE_FINALIZATION {
+			return s.QueryClient.GetAllParticipantDKGRegistrations(context.Background(), codeCommitmentHex, round)
+		}
+
+		log.WithFields(log.Fields{
+			"round":   round,
+			"stage":   network.GetStage().String(),
+			"attempt": attempt + 1,
+		}).Warn("FinalizeDKG: light client has not observed the finalization stage yet, retrying")
+
+		time.Sleep(finalizeStageRetryDelay)
+	}
+
+	return nil, fmt.Errorf("%w: round %d did not reach finalization stage after %d retries",
+		ErrLightClientLag, round, finalizeStageRetryAttempts)
 }
 
 // This matches the validation logic in the Story blockchain DKG module.

--- a/service/dkg_finalize_wait_test.go
+++ b/service/dkg_finalize_wait_test.go
@@ -1,0 +1,89 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+)
+
+// filteredRegs is the post-invalidation participant set the chain agrees on (val1 removed):
+// only the participants that remain VERIFIED/FINALIZED after missing-dealer invalidation.
+func filteredRegs() []*pb.DKGRegistration {
+	return []*pb.DKGRegistration{
+		{Index: 1, Round: 42, ValidatorAddr: "0xC6cB20293dD838C3E839198B9F753c6Ed29e0c9B"}, // val2
+		{Index: 3, Round: 42, ValidatorAddr: "0xc025E30e4ff0A68cB623Ac671933B6FE99eF7Cc7"}, // val4
+	}
+}
+
+// TestWaitForFinalizationRegistrations_WaitsForStage verifies the kernel does not read the
+// participant set while the light client still reports an earlier stage (which would include
+// an invalidated dealer), and only reads it once the finalization stage is observed.
+func TestWaitForFinalizationRegistrations_WaitsForStage(t *testing.T) {
+	stub := &stubQueryClient{
+		networks: []*pb.DKGNetwork{
+			{Round: 42, Stage: pb.DKGStage_DKG_STAGE_DEALING},      // call 1: light client still lagging
+			{Round: 42, Stage: pb.DKGStage_DKG_STAGE_FINALIZATION}, // call 2: caught up to finalization block
+		},
+		registrations: [][]*pb.DKGRegistration{filteredRegs()},
+	}
+
+	s := &DKGServer{QueryClient: stub}
+
+	regs, err := s.waitForFinalizationRegistrations("cc", 42)
+	require.NoError(t, err)
+	require.Equal(t, filteredRegs(), regs)
+	require.Equal(t, int32(2), stub.netCalls.Load(), "polls stage until finalization (1 lag + 1 caught up)")
+	require.Equal(t, int32(1), stub.regCalls.Load(), "registrations read exactly once, after the stage is reached")
+}
+
+// TestWaitForFinalizationRegistrations_Immediate verifies no wait happens when the light
+// client has already observed the finalization stage.
+func TestWaitForFinalizationRegistrations_Immediate(t *testing.T) {
+	stub := &stubQueryClient{
+		networks:      []*pb.DKGNetwork{{Round: 42, Stage: pb.DKGStage_DKG_STAGE_FINALIZATION}},
+		registrations: [][]*pb.DKGRegistration{filteredRegs()},
+	}
+
+	s := &DKGServer{QueryClient: stub}
+
+	regs, err := s.waitForFinalizationRegistrations("cc", 42)
+	require.NoError(t, err)
+	require.Equal(t, filteredRegs(), regs)
+	require.Equal(t, int32(1), stub.netCalls.Load())
+	require.Equal(t, int32(1), stub.regCalls.Load())
+}
+
+// TestWaitForFinalizationRegistrations_RetryExhausted verifies that if the finalization stage
+// is never observed, the call fails with ErrLightClientLag and never reads a stale set.
+func TestWaitForFinalizationRegistrations_RetryExhausted(t *testing.T) {
+	stub := &stubQueryClient{
+		networks:      []*pb.DKGNetwork{{Round: 42, Stage: pb.DKGStage_DKG_STAGE_DEALING}},
+		registrations: [][]*pb.DKGRegistration{filteredRegs()},
+	}
+
+	s := &DKGServer{QueryClient: stub}
+
+	regs, err := s.waitForFinalizationRegistrations("cc", 42)
+	require.Error(t, err)
+	require.Nil(t, regs)
+	require.True(t, errors.Is(err, ErrLightClientLag), "exhaustion must preserve ErrLightClientLag")
+	require.Equal(t, int32(finalizeStageRetryAttempts), stub.netCalls.Load())
+	require.Equal(t, int32(0), stub.regCalls.Load(), "must never read the participant set while lagging")
+}
+
+// TestWaitForFinalizationRegistrations_NetworkError verifies a network query error is returned
+// directly without retrying.
+func TestWaitForFinalizationRegistrations_NetworkError(t *testing.T) {
+	wantErr := errors.New("rpc down")
+	stub := &stubQueryClient{netErr: wantErr}
+
+	s := &DKGServer{QueryClient: stub}
+
+	regs, err := s.waitForFinalizationRegistrations("cc", 42)
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, regs)
+	require.Equal(t, int32(1), stub.netCalls.Load(), "network error must not be retried")
+}


### PR DESCRIPTION
## Problem

The kernel reads participant registrations at its light-client trusted height, which can lag the chain tip. Missing-dealer invalidation happens in the same block that advances the round to the finalization stage, so a lagging read still counts an invalidated dealer as an effective participant. The kernel's participants root then disagrees with the chain's post-invalidation set and finalize is rejected with a participants-root mismatch, stalling the round.

## Fix

Before computing the participants root, wait until the light client has observed the finalization stage (the block that performs invalidation), then read the registrations:

- `waitForFinalizationRegistrations` polls `GetDKGNetwork().Stage` until it reaches `DKG_STAGE_FINALIZATION`, then queries registrations. Since the trusted height is monotonic, observing that stage guarantees the read reflects the invalidation, so the root matches the chain's set.
- Retries on lag (5 × 2s) and returns `ErrLightClientLag` if the stage is never observed.

## Tests

- `waitForFinalizationRegistrations`: waits for stage / immediate / retry-exhausted (never reads a stale set while lagging) / network-error not retried.
- Helper at 100% coverage; service suite passes.

issue: #71 