### PR TITLE
fix(service): persist prev committee state in resharing next build path

### DIFF
--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -506,6 +506,20 @@ func (s *DKGServer) GetResharingNextDKG(
 			return nil, err
 		}
 
+		// Persist the prev committee's public state so a new-committee node
+		// (brand-new joiner or upgraded enclave) has a self-contained store;
+		// without it rebuildResharingNextDKG can't load the prev round after a
+		// restart and deadlocks. Mirrors GetResharingPrevDKG's build branch.
+		if err := s.DKGStore.SetPrevDKGState(
+			codeCommitmentHex,
+			latest.GetRound(),
+			latest.GetThreshold(),
+			prevPubs,
+			publicCoeffs,
+		); err != nil {
+			return nil, err
+		}
+
 		if err := s.DKGStore.SetNextDKGState(
 			codeCommitmentHex,
 			latest.GetRound(),

--- a/service/dkg_resharing_upgrade_test.go
+++ b/service/dkg_resharing_upgrade_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/group/edwards25519"
+
+	"github.com/piplabs/story-kernel/store"
+	"github.com/piplabs/story-kernel/story"
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+)
+
+// upgradePlaintextSealer stores key material as plaintext; the store package's
+// own plaintext sealer is unexported, so we provide an equivalent here.
+type upgradePlaintextSealer struct{}
+
+func (upgradePlaintextSealer) SealToFile(data []byte, path string) error {
+	return os.WriteFile(path, data, 0o600)
+}
+
+func (upgradePlaintextSealer) UnsealFromFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// upgradeStubQC serves a fixed latest-active network and registration set,
+// which is all the resharing build path queries.
+type upgradeStubQC struct {
+	latest *pb.DKGNetwork
+	regs   []*pb.DKGRegistration
+}
+
+var _ story.QueryClient = (*upgradeStubQC)(nil)
+
+func (q *upgradeStubQC) GetLatestActiveDKGNetwork(context.Context) (*pb.DKGNetwork, error) {
+	return q.latest, nil
+}
+
+func (q *upgradeStubQC) GetAllParticipantDKGRegistrations(context.Context, string, uint32) ([]*pb.DKGRegistration, error) {
+	return q.regs, nil
+}
+
+func (q *upgradeStubQC) GetDKGNetwork(context.Context, string, uint32) (*pb.DKGNetwork, error) {
+	return q.latest, nil
+}
+
+func (q *upgradeStubQC) HasDecryptRequest(context.Context, uint32, string, string, string) (bool, error) {
+	return false, nil
+}
+
+func (q *upgradeStubQC) VerifyStartBlock(context.Context, int64, []byte) error { return nil }
+
+func (q *upgradeStubQC) Close() error { return nil }
+
+// TestGetResharingNextDKG_PersistsPrevStateForRestartRebuild covers a new-only
+// joiner (node D below) receiving a resharing round — the general case, of which
+// a fresh code commitment after a kernel upgrade is one instance. The build path
+// must persist the prev-round state so the store is self-contained; without it a
+// restart leaves rebuildResharingNextDKG with no prev round and DKG deadlocks.
+func TestGetResharingNextDKG_PersistsPrevStateForRestartRebuild(t *testing.T) {
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const (
+		cc        = "cc-upgrade"
+		prevRound = uint32(10)
+		toRound   = uint32(14)
+		prevT     = uint32(2)
+		nextT     = uint32(2)
+	)
+
+	point := func(seed int64) kyber.Point {
+		return suite.Point().Mul(suite.Scalar().SetInt64(seed), nil)
+	}
+
+	// Prev committee public material. NewDistKeyHandler wraps PublicCoeffs in a
+	// PubPoly without verifying them at construction, so arbitrary valid points
+	// of length prevT are enough to exercise the build and rebuild paths.
+	prevPubs := []kyber.Point{point(11), point(12), point(13)}
+	regs := make([]*pb.DKGRegistration, len(prevPubs))
+	for i, p := range prevPubs {
+		bz, err := p.MarshalBinary()
+		require.NoError(t, err)
+		regs[i] = &pb.DKGRegistration{Index: uint32(i), Round: prevRound, DkgPubKey: bz}
+	}
+
+	coeffs := []kyber.Point{point(101), point(102)} // len == prevT
+	coeffsBz, err := MarshalPoints(coeffs)
+	require.NoError(t, err)
+
+	// This node joins the next committee as a brand-new member.
+	dScalar := suite.Scalar().SetInt64(777)
+	dBz, err := dScalar.MarshalBinary()
+	require.NoError(t, err)
+	nextPubs := []kyber.Point{suite.Point().Mul(dScalar, nil), point(21), point(22)}
+
+	dir := t.TempDir()
+	st := store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		suite,
+		upgradePlaintextSealer{},
+	)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, toRound, dBz))
+
+	s := &DKGServer{
+		QueryClient: &upgradeStubQC{
+			latest: &pb.DKGNetwork{Round: prevRound, Threshold: prevT, PublicCoeffs: coeffsBz},
+			regs:   regs,
+		},
+		Suite:              suite,
+		DKGStore:           st,
+		ResharingNextCache: store.NewDKGCache(),
+	}
+
+	// Cold cache + fresh store forces the build branch.
+	dkgInst, err := s.GetResharingNextDKG(cc, toRound, nextT, nextPubs)
+	require.NoError(t, err)
+	require.NotNil(t, dkgInst)
+
+	// Load-bearing regression signal: without the fix HasDKGState stays false.
+	hasPrev, err := st.HasDKGState(cc, prevRound)
+	require.NoError(t, err)
+	require.True(t, hasPrev, "build path must persist the prev round state")
+
+	prevState, err := st.LoadDKGState(cc, prevRound)
+	require.NoError(t, err)
+	require.Equal(t, prevT, prevState.Threshold)
+	require.Len(t, prevState.PubKeys, len(prevPubs))
+	require.Len(t, prevState.PublicCoeffs, len(coeffs))
+
+	// Restart: drop the cache and rebuild the round from the store alone.
+	s.ResharingNextCache = store.NewDKGCache()
+	rebuilt, err := s.rebuildResharingNextDKG(cc, toRound)
+	require.NoError(t, err, "rebuild after restart must not fail")
+	require.NotNil(t, rebuilt)
+
+	// Handler-level check: without the prev state kyber builds a non-resharing
+	// handler where this new-only node is a dealer (Deals() returns deals). The
+	// correct resharing receiver has canIssue==false, so Deals() is empty.
+	deals, err := rebuilt.Deals()
+	require.NoError(t, err)
+	require.Empty(t, deals, "rebuilt handler must be a resharing receiver, not a fresh-DKG dealer")
+}


### PR DESCRIPTION
## Problem

`GetResharingNextDKG`'s build branch only persisted the new round via `SetNextDKGState`, leaving its `FromRound` pointing at a prev round that is absent from the store. Any node that joins the new committee without that prev round locally reaches the round only through this next path — its prev path (`GetResharingPrevDKG`) fails early at `LoadSealedEd25519Key(fromRound)` since it holds no prior share. That covers a **brand-new resharing joiner** as well as a **fresh code commitment after a kernel upgrade**. After a restart drops the in-memory cache, `rebuildResharingNextDKG` reads an empty prev state, kyber builds a non-resharing handler, and replay of the round's persisted responses fails — deadlocking DKG on that round.

## Fix

Persist the prev committee's public state (`SetPrevDKGState(codeCommitmentHex, latest.GetRound(), latest.GetThreshold(), prevPubs, publicCoeffs)`) alongside `SetNextDKGState` so the code commitment's store is self-contained. The write uses the same `latest.GetRound()` key that `SetNextDKGState` records as `FromRound`, and the same `prevPubs`/`publicCoeffs` that `buildResharingNextDKG` just consumed — so the rebuilt handler is config-identical to the live one. Mirrors `GetResharingPrevDKG`'s build branch. Only public material is persisted; the overwrite is idempotent (a round's `PublicCoeffs` has a single writer and is always the canonical on-chain GPK).

## Tests

`TestGetResharingNextDKG_PersistsPrevStateForRestartRebuild` — drives a new-only joiner through the build branch, asserts the prev round is persisted (`HasDKGState`), and that after a cold-cache restart `rebuildResharingNextDKG` reconstructs a resharing receiver (`Deals()` empty), not a fresh-DKG dealer. Verified to fail on baseline. `go test ./service/` passes.

issue: https://github.com/piplabs/story-kernel/issues/74