### PR TITLE
chore(dkg): add debug logging for DKG deal flow and proof verification

### DIFF
--- a/service/debug_dump.go
+++ b/service/debug_dump.go
@@ -1,0 +1,140 @@
+package service
+
+// This file holds compact, allocation-light formatting helpers used purely for
+// debug/forensic logging of DKG committee composition. They produce short,
+// comparable fingerprints so the same committee logged from different code
+// paths (chain-fetch vs store-rebuild) or different nodes/rounds can be diffed
+// at a glance.
+//
+// Two committee sources diverge in resharing and are the focus of these dumps:
+//   - chain-fetch path (GetAllParticipantDKGRegistrations): FILTERS OUT
+//     INVALIDATED registrations, so a node invalidated this round disappears
+//     (committee shrinks, e.g. 4 -> 3).
+//   - store-rebuild path (rebuildResharing{Next,Prev}DKG): uses the PubKeys
+//     persisted in DKGState, which were sealed while the node was still
+//     VERIFIED and are NOT re-filtered, so the invalidated node REMAINS
+//     (committee stays 4).
+// When these two disagree, kyber derives a different sessionID and replayed
+// deals fail Schnorr verification — hence dumping both with their source label.
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+
+	"go.dedis.ch/kyber/v4"
+)
+
+// fpLen is the number of leading bytes of a marshaled point used as its
+// fingerprint in debug logs (8 hex chars is enough to disambiguate in practice
+// while keeping log lines short).
+const fpLen = 4
+
+// fmtPubKeys renders a kyber.Point slice as "n=<count>[fp0,fp1,...]" where each
+// fp is the hex of the point's leading bytes. Order is preserved so the same
+// committee built two ways can be compared positionally.
+func fmtPubKeys(pts []kyber.Point) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(pts))
+	for i, p := range pts {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if p == nil {
+			b.WriteString("nil")
+			continue
+		}
+		bz, err := p.MarshalBinary()
+		if err != nil {
+			b.WriteString("ERR")
+			continue
+		}
+		if len(bz) > fpLen {
+			bz = bz[:fpLen]
+		}
+		b.WriteString(hex.EncodeToString(bz))
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+// fmtPubKeyBytes is fmtPubKeys for already-marshaled points (e.g. stored
+// PubKeys / PublicCoeffs as [][]byte).
+func fmtPubKeyBytes(bzs [][]byte) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(bzs))
+	for i, bz := range bzs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if len(bz) > fpLen {
+			bz = bz[:fpLen]
+		}
+		b.WriteString(hex.EncodeToString(bz))
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+// fmtRegs renders a registration slice as "n=<count>[<addr10>#<index>:<status>,...]"
+// so a chain-fetched committee (post-filter) can be compared against the
+// active validator set to see exactly who was dropped (INVALIDATED) and who
+// remained.
+func fmtRegs(regs []*pb.DKGRegistration) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(regs))
+	for i, r := range regs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if r == nil {
+			b.WriteString("nil")
+			continue
+		}
+		addr := r.GetValidatorAddr()
+		if len(addr) > 10 {
+			addr = addr[:10]
+		}
+		fmt.Fprintf(&b, "%s#%d:%s", addr, r.GetIndex(), shortStatus(r.GetStatus()))
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+// shortStatus maps a DKG registration status to a short readable label.
+func shortStatus(st pb.DKGRegStatus) string {
+	switch st {
+	case pb.DKGRegStatus_DKG_REG_STATUS_VERIFIED:
+		return "VER"
+	case pb.DKGRegStatus_DKG_REG_STATUS_FINALIZED:
+		return "FIN"
+	case pb.DKGRegStatus_DKG_REG_STATUS_INVALIDATED:
+		return "INV"
+	default:
+		return st.String()
+	}
+}
+
+// fmtAddrs renders a plain validator-address slice (e.g. ActiveValSet) as
+// "n=<count>[<addr10>,...]".
+func fmtAddrs(addrs []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(addrs))
+	for i, a := range addrs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if len(a) > 10 {
+			a = a[:10]
+		}
+		b.WriteString(a)
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}

--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -280,7 +280,10 @@ func (s *DKGServer) buildResharingPrevDKG(
 		"nextT":           nextT,
 		"num_prevPubs":    len(prevPubs),
 		"num_nextPubs":    len(nextPubs),
+		"old_nodes":       fmtPubKeys(prevPubs),
+		"new_nodes":       fmtPubKeys(nextPubs),
 		"is_resharing":    isResharing,
+		"source":          "chain-fetch build (filtered, INVALIDATED dropped)",
 	}).Info("buildResharingPrevDKG: creating DKG handler")
 	longterm, err := s.DKGStore.LoadSealedEd25519Key(codeCommitmentHex, fromRound)
 	if err != nil {
@@ -374,6 +377,21 @@ func (s *DKGServer) rebuildResharingPrevDKG(
 	if err != nil {
 		return nil, err
 	}
+
+	// DEBUG (Bug2): store-rebuild committee for the PREV-committee handler. As in
+	// rebuildResharingNextDKG, OldNodes/NewNodes are the sealed, UNFILTERED PubKeys
+	// — compare against the chain-fetch committee for the same rounds to spot the
+	// invalidated-node divergence.
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"from_round":      fromRound,
+		"to_round":        toRound,
+		"old_threshold":   prevState.Threshold,
+		"next_threshold":  nextState.Threshold,
+		"old_nodes":       fmtPubKeys(prevState.PubKeys),
+		"new_nodes":       fmtPubKeys(nextState.PubKeys),
+		"source":          "store-rebuild (sealed PubKeys, NOT filtered)",
+	}).Info("rebuildResharingPrevDKG: built handler from sealed state")
 
 	dkgInst, err := dkg.NewDistKeyHandler(&dkg.Config{
 		Suite:        s.Suite,
@@ -545,6 +563,9 @@ func (s *DKGServer) buildResharingNextDKG(codeCommitmentHex string, round, prevT
 		"num_prevPubs":     len(prevPubs),
 		"num_nextPubs":     len(nextPubs),
 		"num_publicCoeffs": len(publicCoeffs),
+		"old_nodes":        fmtPubKeys(prevPubs),
+		"new_nodes":        fmtPubKeys(nextPubs),
+		"source":           "chain-fetch build (filtered, INVALIDATED dropped)",
 	}).Info("buildResharingNextDKG: creating DKG handler")
 	// Create the next DKG
 	nextDKG, err := dkg.NewDistKeyHandler(&dkg.Config{
@@ -596,6 +617,25 @@ func (s *DKGServer) rebuildResharingNextDKG(
 		return nil, err
 	}
 
+	// DEBUG (Bug2): store-rebuild committee. OldNodes/NewNodes here come from the
+	// SEALED DKGState persisted earlier; they are NOT re-filtered, so a validator
+	// that was VERIFIED at seal time but later INVALIDATED still appears in this
+	// set. Compare these fingerprints against the chain-fetch committee logged by
+	// GetAllParticipantDKGRegistrations for the same round — a size/membership
+	// mismatch (e.g. 4 here vs 3 there) is the resharing-reintegration divergence
+	// that makes sessionID/Schnorr verification of replayed deals fail.
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"to_round":        toRound,
+		"from_round":      nextState.FromRound,
+		"old_threshold":   prevState.Threshold,
+		"next_threshold":  nextState.Threshold,
+		"old_nodes":       fmtPubKeys(prevState.PubKeys),
+		"new_nodes":       fmtPubKeys(nextState.PubKeys),
+		"num_deals":       len(nextState.Deals),
+		"source":          "store-rebuild (sealed PubKeys, NOT filtered)",
+	}).Info("rebuildResharingNextDKG: built handler from sealed state")
+
 	if err := replayMessages(dkgInst, nextState); err != nil {
 		return nil, errors.Wrapf(err, "rebuildResharingNextDKG: replay failed (toRound=%d)", toRound)
 	}
@@ -626,11 +666,20 @@ func replayMessages(
 
 	for i, d := range st.Deals {
 		if _, err := dkgInst.ProcessDeal(&d); err != nil {
+			// DEBUG (Bug2): a Schnorr/sessionID failure here usually means the
+			// committee this dkgInst was built with (new_nodes below, plus the
+			// OldNodes logged at the rebuild call site) differs from the committee
+			// the deal was originally created under — i.e. the chain-fetch vs
+			// store-rebuild divergence. dealer_index is in the OLD-committee
+			// (dealer) index space.
 			log.WithFields(log.Fields{
 				"deal_index":   i,
 				"dealer_index": d.Index,
+				"from_round":   st.FromRound,
+				"new_nodes":    fmtPubKeys(st.PubKeys),
+				"num_deals":    len(st.Deals),
 				"error":        err,
-			}).Warn("failed to replay deal")
+			}).Warn("failed to replay deal (likely committee divergence: compare new_nodes vs chain-fetch committee)")
 			criticalErr = true
 		}
 	}

--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -80,7 +80,18 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 	// Generate Distributed Key Share
 	distKeyShare, err := distKeyGen.DistKeyShare()
 	if err != nil {
-		log.Errorf("failed to compute distributed key share: %v", err)
+		// DEBUG (Bug2): "distributed key not certified" here is the symptom the OLD
+		// committee nodes report. Dump the NewNodes committee this Finalize used
+		// (chain-fetch roundContext.SortedPubKeys) and the round so we can tell
+		// which committee (3 vs 4) the cached generator was certified against.
+		log.WithFields(log.Fields{
+			"round":           req.GetRound(),
+			"code_commitment": codeCommitmentHex,
+			"is_resharing":    req.GetIsResharing(),
+			"threshold":       rc.Network.GetThreshold(),
+			"new_nodes":       fmtPubKeys(rc.SortedPubKeys),
+			"committee":       fmtRegs(rc.Registrations),
+		}).Errorf("failed to compute distributed key share: %v", err)
 
 		return nil, status.Errorf(codes.Internal, "failed to compute distributed key share")
 	}
@@ -96,7 +107,12 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 		return nil, status.Errorf(codes.Internal, "distributed key private share is nil")
 	}
 
-	log.Info("Distributed key share has been generated", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"is_resharing":    req.GetIsResharing(),
+		"new_nodes":       fmtPubKeys(rc.SortedPubKeys),
+	}).Info("Distributed key share has been generated")
 
 	pubKeyShare, err := marshalPubShare(priShare.V)
 	if err != nil {

--- a/service/dkg_generate_deals.go
+++ b/service/dkg_generate_deals.go
@@ -113,7 +113,27 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 		log.Warnf("failed to extract dealer polynomial coefficients: %v", extractErr)
 	}
 
-	log.Info("Succeed to generate deals", "code_commitment", codeCommitmentHex, "round", req.GetRound())
+	// DEBUG: report this node's own dealer index and the recipient indices it
+	// produced deals for. deals is map[recipientIndex]*dkg.Deal; every value
+	// carries the same dealer index (this node's position in the OLD committee
+	// for resharing, current committee otherwise). This is what was missing to
+	// tell, from the logs, exactly which validator dealt and to whom.
+	var dealerIndex uint32
+	recipients := make([]int, 0, len(deals))
+	for rcpt, d := range deals {
+		recipients = append(recipients, rcpt)
+		dealerIndex = d.Index
+	}
+
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"is_resharing":    req.GetIsResharing(),
+		"dealer_index":    dealerIndex,
+		"num_deals":       len(deals),
+		"recipient_index": recipients,
+		"num_sorted_pubs": len(rc.SortedPubKeys),
+	}).Info("Succeed to generate deals")
 
 	// Set deals into response
 	resp := createGenerateDealsResponse(req.GetRound(), req.GetCodeCommitment(), deals)

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -141,6 +141,20 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		// handlers and avoids exercising kyber's internal lookup tables
 		// with attacker-chosen indices.
 		if int(deal.Index) >= dealerCount {
+			// DEBUG: previously a silent reject. A deal whose dealer index exceeds
+			// dealerCount usually means the dealer-committee size the kernel built
+			// (dealerCount) disagrees with the committee the deal was made under —
+			// the same chain-fetch vs store-rebuild divergence as Bug2.
+			log.WithFields(log.Fields{
+				"round":           req.GetRound(),
+				"code_commitment": codeCommitmentHex,
+				"sender_index":    deal.Index,
+				"recipient_index": d.GetRecipientIndex(),
+				"dealer_count":    dealerCount,
+				"is_resharing":    req.GetIsResharing(),
+				"reason":          "dealer index >= dealerCount (out of range)",
+			}).Warn("ProcessDeals: rejecting deal with out-of-range dealer index")
+
 			rejected = append(rejected, d)
 
 			continue
@@ -185,11 +199,21 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		}
 	}
 
+	// DEBUG: enumerate which dealer indices were rejected (not just the count) so a
+	// reject can be tied back to a specific dealer/validator via the committee dumps.
+	rejectedIdx := make([]uint32, 0, len(rejected))
+	for _, r := range rejected {
+		rejectedIdx = append(rejectedIdx, r.GetIndex())
+	}
+
 	log.WithFields(log.Fields{
-		"code_commitment": codeCommitmentHex,
-		"round":           req.GetRound(),
-		"processed":       len(deals),
-		"rejected":        len(rejected),
+		"code_commitment":       codeCommitmentHex,
+		"round":                 req.GetRound(),
+		"is_resharing":          req.GetIsResharing(),
+		"dealer_count":          dealerCount,
+		"processed":             len(deals),
+		"rejected":              len(rejected),
+		"rejected_sender_index": rejectedIdx,
 	}).Info("Processed deals")
 
 	return &pb.ProcessDealsResponse{

--- a/service/round_context.go
+++ b/service/round_context.go
@@ -110,6 +110,21 @@ func (s *DKGServer) fetchRoundContext(
 		return nil, err
 	}
 
+	// DEBUG (Bug2): the roundContext committee is the chain-fetch, post-filter set
+	// (INVALIDATED dropped). SortedPubKeys here feeds GetInitDKG/Finalize as
+	// NewNodes; compare against the sealed store-rebuild committee for the same
+	// round to detect the invalidated-node divergence.
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentsHex,
+		"round":           round,
+		"total":           network.GetTotal(),
+		"threshold":       network.GetThreshold(),
+		"is_resharing":    network.GetIsResharing(),
+		"committee":       fmtRegs(registrations),
+		"sorted_pub_keys": fmtPubKeys(sortedPubs),
+		"source":          "chain-fetch roundContext (filtered)",
+	}).Info("fetchRoundContext: assembled round context")
+
 	return &store.RoundContext{
 		Round:         round,
 		Network:       network,

--- a/story/debug_dump.go
+++ b/story/debug_dump.go
@@ -1,0 +1,83 @@
+package story
+
+// Compact formatting helpers for debug/forensic logging in the verified-query
+// client. Kept in the `story` package (separate from service.debug_dump.go,
+// which serves the service package) so committee composition fetched from the
+// chain can be logged in the same comparable shape as the committee rebuilt
+// from sealed state.
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	pb "github.com/piplabs/story-kernel/types/pb/v0"
+)
+
+// fmtRegs renders a registration slice as "n=<count>[<addr10>#<index>:<status>,...]".
+func fmtRegs(regs []*pb.DKGRegistration) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(regs))
+	for i, r := range regs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if r == nil {
+			b.WriteString("nil")
+			continue
+		}
+		addr := r.GetValidatorAddr()
+		if len(addr) > 10 {
+			addr = addr[:10]
+		}
+		fmt.Fprintf(&b, "%s#%d:%s", addr, r.GetIndex(), shortStatus(r.GetStatus()))
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+// shortStatus maps a DKG registration status to a short readable label.
+func shortStatus(st pb.DKGRegStatus) string {
+	switch st {
+	case pb.DKGRegStatus_DKG_REG_STATUS_VERIFIED:
+		return "VER"
+	case pb.DKGRegStatus_DKG_REG_STATUS_FINALIZED:
+		return "FIN"
+	case pb.DKGRegStatus_DKG_REG_STATUS_INVALIDATED:
+		return "INV"
+	default:
+		return st.String()
+	}
+}
+
+// fmtAddrs renders a plain validator-address slice (e.g. ActiveValSet) as
+// "n=<count>[<addr10>,...]".
+func fmtAddrs(addrs []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "n=%d[", len(addrs))
+	for i, a := range addrs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if len(a) > 10 {
+			a = a[:10]
+		}
+		b.WriteString(a)
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+// hexHead returns a short hex prefix of a byte slice for debug logging, with
+// the total length appended so a truncated fingerprint is never mistaken for
+// the full value. Example: "a1b2c3d4..(len=33)".
+func hexHead(bz []byte) string {
+	const head = 8
+	if len(bz) <= head {
+		return hex.EncodeToString(bz)
+	}
+
+	return fmt.Sprintf("%s..(len=%d)", hex.EncodeToString(bz[:head]), len(bz))
+}

--- a/story/query_client.go
+++ b/story/query_client.go
@@ -267,6 +267,12 @@ func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Cont
 	// Not all validators in ActiveValSet may have registered for DKG
 	// (e.g., bootnodes or validators that missed registration).
 	var registrations []*pb.DKGRegistration
+	// DEBUG (Bug2): track the members of ActiveValSet that this chain-fetch path
+	// DROPS, so the resulting committee can be compared against the store-rebuild
+	// committee (which keeps them). noReg = absence-proven (never registered, e.g.
+	// the non-TEE validator); dropped = registered but NOT in VERIFIED/FINALIZED
+	// (the INVALIDATED nodes that vanish here but persist in sealed state).
+	var noReg, dropped []string
 	for _, validatorAddr := range network.GetActiveValSet() {
 		reg, err := q.getDKGRegistration(ctx, codeCommitmentHex, round, validatorAddr)
 		if err != nil {
@@ -276,6 +282,7 @@ func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Cont
 		// Skip validators that didn't register (non-existence proven)
 		if reg == nil {
 			log.Debugf("Validator %s has no DKG registration for round %d, skipping", validatorAddr, round)
+			noReg = append(noReg, validatorAddr)
 
 			continue
 		}
@@ -283,8 +290,24 @@ func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Cont
 		if reg.GetStatus() == pb.DKGRegStatus_DKG_REG_STATUS_VERIFIED ||
 			reg.GetStatus() == pb.DKGRegStatus_DKG_REG_STATUS_FINALIZED {
 			registrations = append(registrations, reg)
+		} else {
+			dropped = append(dropped, fmt.Sprintf("%s:%s", validatorAddr, reg.GetStatus()))
 		}
 	}
+
+	// DEBUG (Bug2): the chain-fetch committee AFTER status filtering. This is the
+	// "size = 3" side of the divergence when a node was invalidated this round.
+	// Compare `committee` here against the OldNodes/NewNodes dumped by
+	// rebuildResharing{Next,Prev}DKG for the same round.
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           round,
+		"active_val_set":  fmtAddrs(network.GetActiveValSet()),
+		"committee":       fmtRegs(registrations),
+		"dropped_status":  dropped,
+		"no_registration": noReg,
+		"source":          "chain-fetch (filters to VERIFIED/FINALIZED)",
+	}).Info("GetAllParticipantDKGRegistrations: built committee from chain")
 
 	if len(registrations) == 0 {
 		return nil, errors.New("no participant registrations found")
@@ -298,13 +321,36 @@ func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Cont
 func (q *VerifiedQueryClient) getDKGRegistration(ctx context.Context, codeCommitmentHex string, round uint32, validatorAddr string) (*pb.DKGRegistration, error) {
 	key := GetDKGRegistrationKey(codeCommitmentHex, round, validatorAddr)
 
+	// DEBUG (Bug1): name the validator whose registration we are about to prove.
+	// When this is a never-registered (e.g. non-TEE) validator, getStoreData must
+	// verify an ICS23 NON-EXISTENCE proof; if that fails the whole roundContext
+	// build fails and dealing is skipped for this round. Logging the validator +
+	// key here is what ties the deeper "non-existence proof failed" error back to
+	// a concrete address (e.g. 0xDB82).
+	log.WithFields(log.Fields{
+		"validator": validatorAddr,
+		"round":     round,
+		"key":       hexHead(key),
+	}).Debug("getDKGRegistration: verifying registration proof")
+
 	bz, err := q.getStoreData(ctx, StoreKey, key)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"validator": validatorAddr,
+			"round":     round,
+			"key":       hexHead(key),
+		}).Warnf("getDKGRegistration: store proof failed for validator: %v", err)
+
 		return nil, fmt.Errorf("failed to get DKG registration: %w", err)
 	}
 
 	// No data means the key doesn't exist (proven by non-existence proof)
 	if len(bz) == 0 {
+		log.WithFields(log.Fields{
+			"validator": validatorAddr,
+			"round":     round,
+		}).Debug("getDKGRegistration: non-existence proof verified (validator has no registration)")
+
 		return nil, nil
 	}
 
@@ -390,11 +436,35 @@ func (q *VerifiedQueryClient) getStoreData(ctx context.Context, storeKey string,
 
 	// Verify the proof chain
 	value := result.Response.Value
+	// DEBUG (Bug1): isNonExistence is true when the queried key has no value at
+	// queryHeight — these go through the ICS23 NON-MEMBERSHIP path, which is the
+	// one observed to fail on a fresh chain while same-height MEMBERSHIP proofs
+	// succeed. Logging height + key + which path on BOTH success and failure lets
+	// us diff a failing absence proof against a succeeding existence proof at the
+	// same height/AppHash.
+	isNonExistence := len(value) == 0
 	if err := q.verifyProof(result.Response.ProofOps, key, value, appHash, queryHeight, nextHeight); err != nil {
+		log.WithFields(log.Fields{
+			"store_key":        storeKey,
+			"key":              hexHead(key),
+			"query_height":     queryHeight,
+			"app_hash_height":  nextHeight,
+			"app_hash":         hexHead(appHash),
+			"is_non_existence": isNonExistence,
+		}).Warnf("getStoreData: proof verification FAILED: %v", err)
+
 		return nil, err
 	}
 
-	log.Debugf("Successfully verified Merkle proof for key: %s at height %d", hex.EncodeToString(key), queryHeight)
+	log.WithFields(log.Fields{
+		"store_key":        storeKey,
+		"key":              hexHead(key),
+		"query_height":     queryHeight,
+		"app_hash_height":  nextHeight,
+		"app_hash":         hexHead(appHash),
+		"is_non_existence": isNonExistence,
+		"value_len":        len(value),
+	}).Debug("getStoreData: proof verified")
 
 	return value, nil
 }
@@ -611,10 +681,61 @@ func verifyModuleNonExistenceProof(
 	spec := getProofSpec(moduleType)
 
 	if !ics23.VerifyNonMembership(spec, expectedModuleRoot, moduleProof, proofKey) {
+		// DEBUG (Bug1): dump everything needed to understand WHY this absence proof
+		// fails while same-height EXISTENCE proofs succeed. See nonExistProofFields.
+		log.WithFields(nonExistProofFields(moduleProof, moduleType, proofKey, expectedModuleRoot)).
+			Warn("verifyModuleNonExistenceProof: VerifyNonMembership FAILED")
+
 		return errors.New("module non-existence proof verification failed: key absence not proven under expected module root")
 	}
 
+	// DEBUG (Bug1): the SUCCESS path dumps the SAME fields as the failure path so a
+	// failing absence proof (rounds 3-4) and a succeeding one for the same absent
+	// key in a later round can be compared field-by-field (neighbors, roots) to
+	// isolate what changes between the intermittent fail and the self-heal.
+	log.WithFields(nonExistProofFields(moduleProof, moduleType, proofKey, expectedModuleRoot)).
+		Debug("verifyModuleNonExistenceProof: absence verified")
+
 	return nil
+}
+
+// nonExistProofFields builds the structured-log fields describing a non-existence
+// proof: the proof key, the expected vs calculated module root (and whether they
+// match), and the Left/Right neighbor keys that bracket the absent key. Shared by
+// both the failure and success branches so the two are directly comparable.
+func nonExistProofFields(
+	moduleProof *ics23.CommitmentProof,
+	moduleType string,
+	proofKey, expectedModuleRoot []byte,
+) log.Fields {
+	fields := log.Fields{
+		"module_type":          moduleType,
+		"proof_key":            hexHead(proofKey),
+		"expected_module_root": hexHead(expectedModuleRoot),
+	}
+	if ne := moduleProof.GetNonexist(); ne != nil {
+		fields["nonexist_key"] = hexHead(ne.GetKey())
+		if l := ne.GetLeft(); l != nil {
+			fields["left_neighbor_key"] = hexHead(l.GetKey())
+		} else {
+			fields["left_neighbor_key"] = "nil"
+		}
+		if r := ne.GetRight(); r != nil {
+			fields["right_neighbor_key"] = hexHead(r.GetKey())
+		} else {
+			fields["right_neighbor_key"] = "nil"
+		}
+	} else {
+		fields["nonexist_proof"] = "nil"
+	}
+	if calcRoot, cerr := moduleProof.Calculate(); cerr == nil {
+		fields["calculated_root"] = hexHead(calcRoot)
+		fields["roots_match"] = bytes.Equal(calcRoot, expectedModuleRoot)
+	} else {
+		fields["calculate_err"] = cerr.Error()
+	}
+
+	return fields
 }
 
 // This proves that key->value exists in the module store with the given moduleRoot.
@@ -643,6 +764,16 @@ func verifyModuleProof(
 
 		return errors.New("module proof verification failed: proof does not match expected module root")
 	}
+
+	// DEBUG (Bug1): a SUCCEEDING existence proof. Logged at the same shape as the
+	// absence-proof failure above so the two can be compared at the same height —
+	// notably whether the expected_module_root matches between an existence proof
+	// that passes and a non-existence proof that fails in the same round.
+	log.WithFields(log.Fields{
+		"module_type":          moduleType,
+		"proof_key":            hexHead(proofKey),
+		"expected_module_root": hexHead(expectedModuleRoot),
+	}).Debug("verifyModuleProof: existence verified")
 
 	return nil
 }


### PR DESCRIPTION
## Motivation

While debugging DKG bootstrap failures on devnet, the existing kernel logging was too sparse to localize what was happening during dealing/finalization — committee construction, deal/response certification, and the verified-query proof checks. This adds debug/forensic logging so those paths are diagnosable from logs.

**Logging-only — no behavior change.**

## What's added

- new `debug_dump` helpers (`fmtPubKeys`/`fmtRegs`/`fmtAddrs`/`hexHead`) — compact, comparable fingerprints of committees and keys.
- `query_client.go` — `getDKGRegistration` names the validator being proven; `getStoreData` logs key/height/`is_non_existence` (success at debug, failure at warn); `verifyModuleNonExistenceProof` dumps proof key, expected vs calculated root and the Left/Right neighbor keys on both success and failure (shared `nonExistProofFields`); `GetAllParticipantDKGRegistrations` dumps the resulting committee plus dropped/unregistered members.
- `round_context.go` — `fetchRoundContext` dumps the committee and sorted pub keys.
- `dist_key_gen.go` — build/rebuild `Resharing{Prev,Next}DKG` dump `OldNodes`/`NewNodes` with a source label; `replayMessages` logs the committee on a deal replay failure.
- `dkg_generate_deals.go` — `GenerateDeals` logs this node's dealer index and recipients.
- `dkg_process_deals.go` — logs the previously-silent out-of-range deal rejection and enumerates rejected sender indices.
- `dkg_finalize.go` — dumps the committee on `distributed key not certified` and on success.

## Log levels

High-frequency per-item logs at `debug` (off by default in production); per-operation committee dumps and summaries at `info`; rejections/failures at `warn`/`error`.

## Context

These logs were used to localize #76 and #77 (and complement piplabs/story#845). Pairs with the story-side debug-logging PR.
