### PR TITLE
fix(dkg): preserve previous committee indices when resharing

### DIFF
--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -690,7 +690,9 @@ func (s *DKGServer) fetchLatestPubKeysAndCoeffs(
 	codeCommitmentHex string,
 	latest *pb.DKGNetwork,
 ) ([]kyber.Point, []kyber.Point, error) {
-	prevRegs, err := s.QueryClient.GetAllParticipantDKGRegistrations(
+	// ALL registrations (any status) to preserve the previous committee's kyber indices when a
+	// member was invalidated. See GetAllRegisteredDKGRegistrations.
+	prevRegs, err := s.QueryClient.GetAllRegisteredDKGRegistrations(
 		context.Background(),
 		codeCommitmentHex,
 		latest.GetRound(),

--- a/service/dkg_partial_decrypt_pid_test.go
+++ b/service/dkg_partial_decrypt_pid_test.go
@@ -25,6 +25,10 @@ func (m *mockQueryClientForPID) GetAllParticipantDKGRegistrations(_ context.Cont
 	return nil, nil
 }
 
+func (m *mockQueryClientForPID) GetAllRegisteredDKGRegistrations(_ context.Context, _ string, _ uint32) ([]*pb.DKGRegistration, error) {
+	return nil, nil
+}
+
 func (m *mockQueryClientForPID) GetLatestActiveDKGNetwork(_ context.Context) (*pb.DKGNetwork, error) {
 	return m.latestNetwork, m.latestErr
 }

--- a/service/dkg_resharing_upgrade_test.go
+++ b/service/dkg_resharing_upgrade_test.go
@@ -45,6 +45,10 @@ func (q *upgradeStubQC) GetAllParticipantDKGRegistrations(context.Context, strin
 	return q.regs, nil
 }
 
+func (q *upgradeStubQC) GetAllRegisteredDKGRegistrations(context.Context, string, uint32) ([]*pb.DKGRegistration, error) {
+	return q.regs, nil
+}
+
 func (q *upgradeStubQC) GetDKGNetwork(context.Context, string, uint32) (*pb.DKGNetwork, error) {
 	return q.latest, nil
 }

--- a/service/round_context_test.go
+++ b/service/round_context_test.go
@@ -50,6 +50,10 @@ func (s *stubQueryClient) GetAllParticipantDKGRegistrations(_ context.Context, _
 	return s.registrations[i], nil
 }
 
+func (s *stubQueryClient) GetAllRegisteredDKGRegistrations(ctx context.Context, cc string, round uint32) ([]*pb.DKGRegistration, error) {
+	return s.GetAllParticipantDKGRegistrations(ctx, cc, round)
+}
+
 // Unused interface methods — panic loudly if accidentally invoked.
 func (*stubQueryClient) GetLatestActiveDKGNetwork(_ context.Context) (*pb.DKGNetwork, error) {
 	panic("stubQueryClient.GetLatestActiveDKGNetwork: not implemented for round_context tests")

--- a/story/query_client.go
+++ b/story/query_client.go
@@ -43,6 +43,7 @@ const (
 type QueryClient interface {
 	GetDKGNetwork(ctx context.Context, codeCommitmentHex string, round uint32) (*pb.DKGNetwork, error)
 	GetAllParticipantDKGRegistrations(ctx context.Context, codeCommitmentHex string, round uint32) ([]*pb.DKGRegistration, error)
+	GetAllRegisteredDKGRegistrations(ctx context.Context, codeCommitmentHex string, round uint32) ([]*pb.DKGRegistration, error)
 	GetLatestActiveDKGNetwork(ctx context.Context) (*pb.DKGNetwork, error)
 	HasDecryptRequest(ctx context.Context, round uint32, requesterPubKeyHex string, labelHex string, ciphertextHex string) (bool, error)
 	VerifyStartBlock(ctx context.Context, startBlockHeight int64, startBlockHash []byte) error
@@ -248,11 +249,22 @@ func (q *VerifiedQueryClient) GetDKGNetwork(ctx context.Context, codeCommitmentH
 	return &network, nil
 }
 
-// GetAllParticipantDKGRegistrations returns all DKG registrations that are part of
-// the active participant set (VERIFIED or FINALIZED status). Both statuses must be
-// included because validators finalize at different times — earlier finalizers
-// transition their status from VERIFIED to FINALIZED before later finalizers query.
+// GetAllParticipantDKGRegistrations returns the round's VERIFIED/FINALIZED registrations. Use
+// it where only currently-valid participants matter (e.g. finalization counting).
 func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Context, codeCommitmentHex string, round uint32) ([]*pb.DKGRegistration, error) {
+	return q.collectDKGRegistrations(ctx, codeCommitmentHex, round, true)
+}
+
+// GetAllRegisteredDKGRegistrations returns ALL of the round's registrations regardless of status
+// (skipping only validators that never registered). Resharing builds the previous committee from
+// this set so an invalidated member keeps its slot and the survivors' kyber indices are preserved.
+func (q *VerifiedQueryClient) GetAllRegisteredDKGRegistrations(ctx context.Context, codeCommitmentHex string, round uint32) ([]*pb.DKGRegistration, error) {
+	return q.collectDKGRegistrations(ctx, codeCommitmentHex, round, false)
+}
+
+// collectDKGRegistrations queries each registered validator in the round's active set. When
+// onlyParticipants is true it keeps only VERIFIED/FINALIZED registrations.
+func (q *VerifiedQueryClient) collectDKGRegistrations(ctx context.Context, codeCommitmentHex string, round uint32, onlyParticipants bool) ([]*pb.DKGRegistration, error) {
 	// First get the network to know which validators are registered
 	network, err := q.GetDKGNetwork(ctx, codeCommitmentHex, round)
 	if err != nil {
@@ -280,10 +292,13 @@ func (q *VerifiedQueryClient) GetAllParticipantDKGRegistrations(ctx context.Cont
 			continue
 		}
 
-		if reg.GetStatus() == pb.DKGRegStatus_DKG_REG_STATUS_VERIFIED ||
-			reg.GetStatus() == pb.DKGRegStatus_DKG_REG_STATUS_FINALIZED {
-			registrations = append(registrations, reg)
+		if onlyParticipants &&
+			reg.GetStatus() != pb.DKGRegStatus_DKG_REG_STATUS_VERIFIED &&
+			reg.GetStatus() != pb.DKGRegStatus_DKG_REG_STATUS_FINALIZED {
+			continue
 		}
+
+		registrations = append(registrations, reg)
 	}
 
 	if len(registrations) == 0 {

--- a/story/query_client_test.go
+++ b/story/query_client_test.go
@@ -2588,6 +2588,73 @@ func TestGetAllParticipantDKGRegistrations_NoVerifiedRegistrations(t *testing.T)
 	mockLC.AssertExpectations(t)
 }
 
+// TestGetAllRegisteredDKGRegistrations_IncludesInvalidated verifies that the resharing query
+// keeps an INVALIDATED registration (so its committee slot is preserved), whereas the
+// participant query drops it.
+func TestGetAllRegisteredDKGRegistrations_IncludesInvalidated(t *testing.T) {
+	cdc := MakeCodec()
+	queryHeight := int64(100)
+
+	network := &pb.DKGNetwork{
+		Round:        1,
+		ActiveValSet: []string{"val1"},
+		Total:        1,
+		Threshold:    1,
+	}
+	encodedNetwork, err := cdc.Marshal(network)
+	require.NoError(t, err)
+
+	// A registration that was invalidated after dealing — must still be returned.
+	reg := &pb.DKGRegistration{
+		Round:     1,
+		Index:     1,
+		DkgPubKey: []byte("pk1"),
+		Status:    pb.DKGRegStatus_DKG_REG_STATUS_INVALIDATED,
+	}
+	encodedReg, _ := cdc.Marshal(reg)
+
+	networkKey := GetDKGNetworkKey("test_cc", 1)
+	regKey := GetDKGRegistrationKey("test_cc", 1, "val1")
+
+	networkResult, networkAppHash := makeVerifiedABCIResult(networkKey, encodedNetwork, queryHeight, StoreKey)
+	regResult, regAppHash := makeVerifiedABCIResult(regKey, encodedReg, queryHeight, StoreKey)
+
+	mockRPC := new(MockRPCClient)
+	mockRPC.On("ABCIQueryWithOptions", mock.Anything, mock.Anything, mock.MatchedBy(func(data cmtbytes.HexBytes) bool {
+		return bytes.Equal(data, cmtbytes.HexBytes(networkKey))
+	}), mock.Anything).Return(networkResult, nil).Once()
+	mockRPC.On("ABCIQueryWithOptions", mock.Anything, mock.Anything, mock.MatchedBy(func(data cmtbytes.HexBytes) bool {
+		return bytes.Equal(data, cmtbytes.HexBytes(regKey))
+	}), mock.Anything).Return(regResult, nil).Once()
+
+	mockLC := new(MockLightClient)
+	networkLB := &cmttypes.LightBlock{SignedHeader: &cmttypes.SignedHeader{Header: &cmttypes.Header{Height: queryHeight + 1, AppHash: cmtbytes.HexBytes(networkAppHash)}}}
+	regLB := &cmttypes.LightBlock{SignedHeader: &cmttypes.SignedHeader{Header: &cmttypes.Header{Height: queryHeight + 1, AppHash: cmtbytes.HexBytes(regAppHash)}}}
+	mockLC.On("VerifyLightBlockAtHeight", mock.Anything, queryHeight+1, mock.Anything).Return(networkLB, nil).Once()
+	mockLC.On("VerifyLightBlockAtHeight", mock.Anything, queryHeight+1, mock.Anything).Return(regLB, nil).Once()
+
+	client := &VerifiedQueryClient{
+		cfg: &config.Config{
+			LightClient: config.LightClientConfig{
+				MaxBlockWaitRetries: 1,
+				BlockWaitRetryDelay: 1 * time.Millisecond,
+			},
+		},
+		rpcClient:   mockRPC,
+		lightClient: mockLC,
+		mutex:       &sync.Mutex{},
+		cdc:         cdc,
+	}
+	client.cachedLastBlockHeight.Store(queryHeight)
+
+	regs, err := client.GetAllRegisteredDKGRegistrations(t.Context(), "test_cc", 1)
+	require.NoError(t, err, "invalidated registration must be kept to preserve its committee slot")
+	require.Len(t, regs, 1)
+	assert.Equal(t, pb.DKGRegStatus_DKG_REG_STATUS_INVALIDATED, regs[0].GetStatus())
+	mockRPC.AssertExpectations(t)
+	mockLC.AssertExpectations(t)
+}
+
 func TestGetAllParticipantDKGRegistrations_RegistrationQueryFails(t *testing.T) {
 	cdc := MakeCodec()
 	queryHeight := int64(100)


### PR DESCRIPTION
## Problem

When building the previous committee for a resharing round, `fetchLatestPubKeysAndCoeffs` queried `GetAllParticipantDKGRegistrations`, which drops `INVALIDATED` registrations and densely re-indexes the survivors. kyber resharing verifies each old dealer's committed share against `dpub.Eval(committeePosition)`, so a survivor whose position shifts (because an earlier committee member was invalidated) is rejected — resharing breaks the first time a previous-committee member is invalidated.

## Fix

Add `GetAllRegisteredDKGRegistrations` (returns every registration regardless of status, skipping only validators that never registered) and build the resharing previous committee (`OldNodes`) from it, so an invalidated member keeps its slot and the survivors' kyber indices are preserved. This matches the sealed (store-rebuild) committee. The participant/finalization callers (`fetchRoundContext`, `waitForFinalizationRegistrations`) keep the filtered query.

## Why preserve indices instead of filtering

A dealer's position in `OldNodes` must equal the index its share was created at, because the new committee verifies each old deal against `dpub.Eval(position)`. Re-compacting after an invalidation shifts that position and the check fails. So both the kernel and the chain keep the full committee rather than filtering.

## Tests

- `TestGetAllRegisteredDKGRegistrations_IncludesInvalidated` — the resharing query keeps an `INVALIDATED` registration (slot preserved) while the participant query drops it.
- `service` + `story` suites pass (cb-mpc build).

## Compatibility

No behavior change while no committee member has been invalidated: for a contiguous, all-`VERIFIED` committee the full and filtered sets are identical. Diverges only on a gap, which has never occurred on aeneid. Ship together with the companion chain change.

issue: https://github.com/piplabs/story/issues/851
