### PR TITLE
fix(service): re-emit stored responses when ProcessDeals dedups retried deals

### DIFF
--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -218,6 +218,13 @@ func (s *DKGServer) applyDeals(
 				return nil, 0, nil, rerr
 			}
 			if pbResp != nil {
+				// Recovery path: confirm the stored response was recovered on retry.
+				log.WithFields(log.Fields{
+					"round":           round,
+					"code_commitment": codeCommitmentHex,
+					"sender_index":    deal.Index,
+				}).Info("re-emitted stored response for retried deal")
+
 				pbResps = append(pbResps, pbResp)
 			} else {
 				// No stored response (e.g. crash between processing and persist).

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -250,6 +250,14 @@ func (s *DKGServer) applyDeals(
 	// dropped connection can re-emit the responses instead of losing them.
 	if len(deals) > 0 {
 		if err := s.DKGStore.AddProcessedDeals(codeCommitmentHex, round, deals, emittedResps); err != nil {
+			// Persist failed after kyber absorbed the deals in memory. Evict the
+			// round's cached generator so the retry rebuilds from persisted state
+			// (which lacks these deals) and re-processes cleanly. The generator is
+			// in InitDKGCache or ResharingNextCache (both round-keyed; Delete is a
+			// no-op when absent, so evicting both is safe).
+			s.InitDKGCache.Delete(round)
+			s.ResharingNextCache.Delete(round)
+
 			return nil, 0, nil, err
 		}
 	}

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -127,12 +127,69 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		}
 	}
 
+	// Serialize with any concurrent DKG-mutating RPC for this round: a client
+	// timeout leaves the abandoned server handler running, and its retry (or an
+	// adjacent ProcessResponses/Justification) must not mutate the shared
+	// DistKeyGenerator at the same time. Held across process+persist so the
+	// retry sees a fully persisted state and re-emits deterministically.
+	mu := s.getDKGMutationMu(req.GetRound())
+	mu.Lock()
+	pbResps, persisted, rejected, err := s.applyDeals(distKeyGen, codeCommitmentHex, req.GetRound(), dealerCount, req.GetDeals())
+	mu.Unlock()
+	if err != nil {
+		log.Errorf("failed to persist processed deals: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to persist processed deals")
+	}
+
+	// responses = total emitted this call (incl. re-emitted on retry);
+	// persisted_deals = deals newly stored this call (0 on a pure retry).
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"responses":       len(pbResps),
+		"persisted_deals": persisted,
+		"rejected":        len(rejected),
+	}).Info("Processed deals")
+
+	return &pb.ProcessDealsResponse{
+		CodeCommitment: req.GetCodeCommitment(),
+		Round:          req.GetRound(),
+		Responses:      pbResps,
+		RejectedDeals:  rejected,
+	}, nil
+}
+
+// applyDeals runs each incoming deal through the cached DistKeyGenerator,
+// persisting each deal with the response it generated. On a retried deal that
+// kyber already absorbed, it re-emits the stored response instead of losing the
+// verifier's approval.
+func (s *DKGServer) applyDeals(
+	distKeyGen *dkg.DistKeyGenerator,
+	codeCommitmentHex string,
+	round uint32,
+	dealerCount int,
+	reqDeals []*pb.Deal,
+) ([]*pb.Response, int, []*pb.Deal, error) {
 	var (
-		pbResps  []*pb.Response
-		deals    []dkg.Deal
-		rejected []*pb.Deal
+		pbResps      []*pb.Response
+		deals        []dkg.Deal
+		emittedResps []dkg.Response
+		rejected     []*pb.Deal
 	)
-	for _, d := range req.GetDeals() {
+
+	// EmittedResponses are loaded from disk at most once, and only if a retried
+	// deal actually needs one — a normal call never reads state back.
+	storedEmitted := &lazy[[]dkg.Response]{load: func() ([]dkg.Response, error) {
+		st, err := s.DKGStore.LoadDKGState(codeCommitmentHex, round)
+		if err != nil {
+			return nil, err
+		}
+
+		return st.EmittedResponses, nil
+	}}
+
+	for _, d := range reqDeals {
 		deal := types.ConvertToDeal(d)
 
 		// Defence in depth: bounds-check the dealer index before kyber.
@@ -147,57 +204,68 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		}
 
 		resp, err := distKeyGen.ProcessDeal(deal)
-		if err != nil {
-			// Idempotent re-submission: the cached DistKeyGenerator has already
-			// absorbed this deal. Silent skip — do NOT include in rejected_deals
-			// so the client does not retry an artifact kyber will keep rejecting.
-			if isAlreadyProcessedErr(err) {
+		switch {
+		case err == nil:
+			pbResps = append(pbResps, types.ConvertToRespProto(resp))
+			deals = append(deals, *deal)
+			emittedResps = append(emittedResps, *resp)
+
+		case isAlreadyProcessedErr(err):
+			// Retried deal kyber already absorbed: re-emit the response stored
+			// for it so the verifier's approval is not lost. Never rejected.
+			pbResp, rerr := reEmitResponse(storedEmitted, deal.Index)
+			if rerr != nil {
+				return nil, 0, nil, rerr
+			}
+			if pbResp != nil {
+				pbResps = append(pbResps, pbResp)
+			} else {
+				// No stored response (e.g. crash between processing and persist).
 				log.WithFields(log.Fields{
-					"round":           req.GetRound(),
+					"round":           round,
 					"code_commitment": codeCommitmentHex,
 					"sender_index":    deal.Index,
-				}).Debugf("deal already stored on cached generator; skipping silently: %v", err)
-
-				continue
+				}).Warn("deal already processed but no stored response to re-emit; skipping")
 			}
 
+		default:
 			log.WithFields(log.Fields{
-				"round":           req.GetRound(),
+				"round":           round,
 				"code_commitment": codeCommitmentHex,
 				"sender_index":    deal.Index,
 			}).Errorf("failed to process the deal: %v", err)
 
 			rejected = append(rejected, d)
-
-			continue
 		}
-
-		pbResp := types.ConvertToRespProto(resp)
-		pbResps = append(pbResps, pbResp)
-		deals = append(deals, *deal)
 	}
 
+	// Persist deals and their generated responses atomically so a retry after a
+	// dropped connection can re-emit the responses instead of losing them.
 	if len(deals) > 0 {
-		if err := s.DKGStore.AddDeals(codeCommitmentHex, req.GetRound(), deals); err != nil {
-			log.Errorf("failed to add deals to the DKG state: %v", err)
-
-			return nil, status.Errorf(codes.Internal, "failed to add deals to the DKG state")
+		if err := s.DKGStore.AddProcessedDeals(codeCommitmentHex, round, deals, emittedResps); err != nil {
+			return nil, 0, nil, err
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"code_commitment": codeCommitmentHex,
-		"round":           req.GetRound(),
-		"processed":       len(deals),
-		"rejected":        len(rejected),
-	}).Info("Processed deals")
+	return pbResps, len(deals), rejected, nil
+}
 
-	return &pb.ProcessDealsResponse{
-		CodeCommitment: req.GetCodeCommitment(),
-		Round:          req.GetRound(),
-		Responses:      pbResps,
-		RejectedDeals:  rejected,
-	}, nil
+// reEmitResponse returns the response this node persisted for dealerIndex on a
+// prior call so a retried deal recovers it, or nil if none was stored (keyed by
+// dealer index, at most one per index).
+func reEmitResponse(stored *lazy[[]dkg.Response], dealerIndex uint32) (*pb.Response, error) {
+	emitted, err := stored.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range emitted {
+		if emitted[i].Index == dealerIndex {
+			return types.ConvertToRespProto(&emitted[i]), nil
+		}
+	}
+
+	return nil, nil
 }
 
 func validateProcessDealsRequest(req *pb.ProcessDealsRequest) error {

--- a/service/dkg_process_deals_test.go
+++ b/service/dkg_process_deals_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -409,6 +410,63 @@ func TestApplyDeals_MissingEmittedResponsesSilentlySkips(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, resps, "no stored emitted responses means nothing to re-emit")
 	require.Empty(t, rej, "dedup must never reject")
+}
+
+// TestApplyDeals_EvictsCachedGeneratorOnPersistFailure is the regression test
+// for PR #87: when AddProcessedDeals fails after kyber has already absorbed the
+// deals in memory, applyDeals must evict the round's cached generator so the
+// next retry rebuilds a fresh one from persisted state (which lacks these
+// deals) and re-processes cleanly — rather than hitting kyber's
+// already-processed path with nothing on disk to re-emit.
+func TestApplyDeals_EvictsCachedGeneratorOnPersistFailure(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cc        = "cc-persist-fail"
+		round     = uint32(1)
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	self := 0
+	reqDeals := dealsAddressedTo(t, gens, self)
+
+	// Point the state directory at a regular file so every state read/write
+	// fails: this makes AddProcessedDeals return an error after kyber has
+	// already absorbed the deals in memory, reproducing the persist-fail case.
+	dir := t.TempDir()
+	stateAsFile := filepath.Join(dir, "state-as-file")
+	require.NoError(t, os.WriteFile(stateAsFile, []byte("x"), 0o600))
+
+	st := store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		stateAsFile,
+		suite,
+		upgradePlaintextSealer{},
+	)
+
+	s := &DKGServer{
+		Suite:              suite,
+		DKGStore:           st,
+		InitDKGCache:       store.NewDKGCache(),
+		ResharingNextCache: store.NewDKGCache(),
+	}
+
+	// Seed both round-keyed caches: an initial round lives in InitDKGCache and a
+	// resharing round in ResharingNextCache; applyDeals evicts both defensively.
+	s.InitDKGCache.Set(round, gens[self])
+	s.ResharingNextCache.Set(round, gens[self])
+
+	_, _, _, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+	require.Error(t, err, "persist failure must surface an error")
+
+	_, ok := s.InitDKGCache.Get(round)
+	require.False(t, ok, "InitDKGCache generator must be evicted after persist failure")
+
+	_, ok = s.ResharingNextCache.Get(round)
+	require.False(t, ok, "ResharingNextCache generator must be evicted after persist failure")
 }
 
 // TestProcessDeals_ConcurrentRoundSerialized reproduces the timeout-then-retry

--- a/service/dkg_process_deals_test.go
+++ b/service/dkg_process_deals_test.go
@@ -3,11 +3,20 @@ package service
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/group/edwards25519"
+	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/piplabs/story-kernel/store"
+	"github.com/piplabs/story-kernel/types"
 	pb "github.com/piplabs/story-kernel/types/pb/v0"
 )
 
@@ -208,4 +217,250 @@ func errJustificationOnApprovalVerbatim() error {
 // isAlreadyProcessedErr handles wrapped errors via fmt.Errorf "%w".
 func errWrap(inner error) error {
 	return fmt.Errorf("kernel: %w", inner)
+}
+
+// --- applyDeals re-emit tests (issue #84) ---
+
+// freshDKGGens builds n Pedersen DKG generators with fresh longterm keys.
+// Nothing is exchanged yet, so a generator produces a real response the first
+// time it processes a deal and an idempotent error on re-submission.
+func freshDKGGens(t *testing.T, suite *edwards25519.SuiteEd25519, n, threshold int) []*dkg.DistKeyGenerator {
+	t.Helper()
+
+	pubs := make([]kyber.Point, n)
+	longterms := make([]kyber.Scalar, n)
+	for i := 0; i < n; i++ {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	return gens
+}
+
+// dealToProto is the inverse of types.ConvertToDeal for building test inputs.
+func dealToProto(d *dkg.Deal) *pb.Deal {
+	return &pb.Deal{
+		Index: d.Index,
+		Deal: &pb.EncryptedDeal{
+			DhKey:     d.Deal.DHKey,
+			Signature: d.Deal.Signature,
+			Nonce:     d.Deal.Nonce,
+			Cipher:    d.Deal.Cipher,
+		},
+		Signature: d.Signature,
+	}
+}
+
+// dealsAddressedTo collects, as proto, the deals every other dealer produced
+// for verifier self (Deal.Index is the dealer index, per kyber d.oidx).
+func dealsAddressedTo(t *testing.T, gens []*dkg.DistKeyGenerator, self int) []*pb.Deal {
+	t.Helper()
+
+	var out []*pb.Deal
+	for dealer := range gens {
+		if dealer == self {
+			continue
+		}
+		deals, err := gens[dealer].Deals()
+		require.NoError(t, err)
+		d, ok := deals[self]
+		require.True(t, ok, "dealer %d must address verifier %d", dealer, self)
+		out = append(out, dealToProto(d))
+	}
+
+	return out
+}
+
+func newServiceTestStore(t *testing.T) *store.DKGStore {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	return store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		edwards25519.NewBlakeSHA256Ed25519(),
+		upgradePlaintextSealer{},
+	)
+}
+
+func marshalResp(t *testing.T, r *pb.Response) []byte {
+	t.Helper()
+
+	b, err := proto.Marshal(r)
+	require.NoError(t, err)
+
+	return b
+}
+
+// TestApplyDeals_ReemitsStoredResponsesOnResubmit is the regression test for
+// issue #84: when a ProcessDeals call is retried (the first response died with a
+// timed-out connection), the cached generator returns already-processed, and
+// applyDeals must re-emit the byte-identical responses it generated the first
+// time — never dropping the verifier's approvals.
+func TestApplyDeals_ReemitsStoredResponsesOnResubmit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cc        = "cc-reemit"
+		round     = uint32(1)
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	self := 0
+	reqDeals := dealsAddressedTo(t, gens, self)
+	require.Len(t, reqDeals, n-1)
+
+	s := &DKGServer{Suite: suite, DKGStore: newServiceTestStore(t)}
+
+	// First call processes the deals and persists deals + own responses.
+	resp1, _, rej1, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+	require.NoError(t, err)
+	require.Empty(t, rej1)
+	require.Len(t, resp1, len(reqDeals))
+
+	// Retry: same deals, same cached generator -> kyber returns already-processed.
+	resp2, _, rej2, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+	require.NoError(t, err)
+	require.Empty(t, rej2, "re-submitted deals must not be rejected")
+	require.Len(t, resp2, len(resp1), "retry must re-emit every response")
+
+	for i := range resp1 {
+		require.Equal(t, marshalResp(t, resp1[i]), marshalResp(t, resp2[i]),
+			"re-emitted response %d must be byte-identical to the original", i)
+	}
+}
+
+// TestApplyDeals_EmittedResponsesStoredSeparately guards replay semantics: the
+// generated responses land in EmittedResponses, and the peer-facing Responses field
+// (read by replayMessages and the rebuild paths) stays empty.
+func TestApplyDeals_EmittedResponsesStoredSeparately(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cc        = "cc-separate"
+		round     = uint32(1)
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	self := 0
+	reqDeals := dealsAddressedTo(t, gens, self)
+
+	s := &DKGServer{Suite: suite, DKGStore: newServiceTestStore(t)}
+
+	_, _, _, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+	require.NoError(t, err)
+
+	st, err := s.DKGStore.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Empty(t, st.Responses, "peers' Responses must stay empty")
+	require.Len(t, st.EmittedResponses, len(reqDeals), "emitted responses must be persisted")
+	require.Len(t, st.Deals, len(reqDeals), "deals must be persisted alongside")
+}
+
+// TestApplyDeals_MissingEmittedResponsesSilentlySkips covers the crash-between edge:
+// the generator already absorbed the deal but no own response was persisted
+// (deals persisted without emitted responses). The dedup path must skip silently — no response, no
+// rejection.
+func TestApplyDeals_MissingEmittedResponsesSilentlySkips(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cc        = "cc-missing"
+		round     = uint32(1)
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	self := 0
+	reqDeals := dealsAddressedTo(t, gens, self)
+
+	// Absorb the deals so a later ProcessDeal returns already-processed, and
+	// persist them via the legacy path that stores no own responses.
+	raw := make([]dkg.Deal, 0, len(reqDeals))
+	for _, pd := range reqDeals {
+		d := types.ConvertToDeal(pd)
+		_, err := gens[self].ProcessDeal(d)
+		require.NoError(t, err)
+		raw = append(raw, *d)
+	}
+
+	st := newServiceTestStore(t)
+	require.NoError(t, st.AddProcessedDeals(cc, round, raw, nil))
+
+	s := &DKGServer{Suite: suite, DKGStore: st}
+
+	resps, _, rej, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+	require.NoError(t, err)
+	require.Empty(t, resps, "no stored emitted responses means nothing to re-emit")
+	require.Empty(t, rej, "dedup must never reject")
+}
+
+// TestProcessDeals_ConcurrentRoundSerialized reproduces the timeout-then-retry
+// race: an abandoned handler and its retry run concurrently against the same
+// cached generator. Guarded by getDKGMutationMu (as ProcessDeals does), the two
+// runs serialize — one processes, the other re-emits — with no data race
+// (run with -race) and no duplicate own responses.
+func TestProcessDeals_ConcurrentRoundSerialized(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cc        = "cc-concurrent"
+		round     = uint32(1)
+		n         = 3
+		threshold = 2
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	self := 0
+	reqDeals := dealsAddressedTo(t, gens, self)
+
+	s := &DKGServer{Suite: suite, DKGStore: newServiceTestStore(t)}
+
+	// Mirror ProcessDeals' lock discipline in two goroutines sharing gens[self].
+	run := func() ([]*pb.Response, error) {
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		resps, _, _, err := s.applyDeals(gens[self], cc, round, n, reqDeals)
+
+		return resps, err
+	}
+
+	var (
+		wg         sync.WaitGroup
+		r1, r2     []*pb.Response
+		err1, err2 error
+	)
+	wg.Add(2)
+	go func() { defer wg.Done(); r1, err1 = run() }()
+	go func() { defer wg.Done(); r2, err2 = run() }()
+	wg.Wait()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	// Both runs return the full response set (one fresh, one re-emitted).
+	require.Len(t, r1, len(reqDeals))
+	require.Len(t, r2, len(reqDeals))
+
+	// Serialized process+persist must leave exactly one own response per dealer.
+	st, err := s.DKGStore.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Len(t, st.EmittedResponses, len(reqDeals), "no duplicate own responses")
 }

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -119,6 +119,12 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 		justs    []dkg.Justification
 		rejected []*pb.Justification
 	)
+
+	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
+	// RPCs for this round (see dkgMutationMu). Persist runs after the loop under
+	// its own store lock, so only the kyber mutation needs covering here.
+	mu := s.getDKGMutationMu(req.GetRound())
+	mu.Lock()
 	for _, j := range req.GetJustifications() {
 		justification, err := types.ConvertToJustification(j)
 		if err != nil {
@@ -201,6 +207,7 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 			"dealer_index":    justification.Index,
 		}).Info("Justification processed successfully, DKG state restored for the deal")
 	}
+	mu.Unlock()
 
 	// Persist successfully processed justifications for recovery replay
 	if len(justs) > 0 {

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -125,6 +125,12 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 		resps          []dkg.Response
 		rejected       []*pb.Response
 	)
+
+	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
+	// RPCs for this round (see dkgMutationMu). Persist runs after the loop under
+	// its own store lock, so only the kyber mutation needs covering here.
+	mu := s.getDKGMutationMu(req.GetRound())
+	mu.Lock()
 	for _, response := range req.GetResponses() {
 		resp := types.ConvertToVSSResp(response)
 
@@ -212,6 +218,7 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 
 		resps = append(resps, *resp)
 	}
+	mu.Unlock()
 
 	if len(resps) > 0 {
 		if err := s.DKGStore.AddResponses(codeCommitmentHex, req.GetRound(), resps); err != nil {

--- a/service/dkg_server.go
+++ b/service/dkg_server.go
@@ -31,6 +31,13 @@ type DKGServer struct {
 	initDKGMu     sync.Map // map[uint32]*sync.Mutex
 	resharePrevMu sync.Map // map[uint64]*sync.Mutex  (fromRound<<32 | toRound)
 	reshareNextMu sync.Map // map[uint32]*sync.Mutex
+
+	// dkgMutationMu serializes the DKG-mutating RPCs (ProcessDeals,
+	// ProcessResponses, ProcessJustification) for a round. The cached
+	// DistKeyGenerator is unsynchronized; a client timeout does not stop the
+	// server handler, so a retry — or an adjacent mutating RPC — can run
+	// concurrently with the abandoned call and corrupt the shared instance.
+	dkgMutationMu sync.Map // map[uint32]*sync.Mutex
 }
 
 func (s *DKGServer) getInitDKGMu(round uint32) *sync.Mutex {
@@ -41,6 +48,11 @@ func (s *DKGServer) getInitDKGMu(round uint32) *sync.Mutex {
 func (s *DKGServer) getResharePrevMu(fromRound, toRound uint32) *sync.Mutex {
 	key := uint64(fromRound)<<32 | uint64(toRound)
 	v, _ := s.resharePrevMu.LoadOrStore(key, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func (s *DKGServer) getDKGMutationMu(round uint32) *sync.Mutex {
+	v, _ := s.dkgMutationMu.LoadOrStore(round, &sync.Mutex{})
 	return v.(*sync.Mutex)
 }
 

--- a/service/utils.go
+++ b/service/utils.go
@@ -82,3 +82,24 @@ func reverseBytes(in []byte) []byte {
 
 	return out
 }
+
+// lazy memoizes a value produced by load, running it at most once on the first
+// Get. It lets a request defer an expensive load (e.g. reading DKG state from
+// disk) so the normal path pays nothing, while a retry loads it exactly once and
+// reuses it for every subsequent item in the same call. Not safe for concurrent
+// use — intended for a single request goroutine.
+type lazy[T any] struct {
+	load   func() (T, error)
+	value  T
+	loaded bool
+	err    error
+}
+
+func (l *lazy[T]) Get() (T, error) {
+	if !l.loaded {
+		l.value, l.err = l.load()
+		l.loaded = true
+	}
+
+	return l.value, l.err
+}

--- a/store/dkg_cache.go
+++ b/store/dkg_cache.go
@@ -113,6 +113,25 @@ func (c *DKGCache) evictIfFull() {
 	}
 }
 
+// Delete removes the entry for round, if present. It is a safe no-op when the
+// round is absent, so callers may evict unconditionally.
+func (c *DKGCache) Delete(round uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := strconv.FormatUint(uint64(round), 10)
+	if _, exists := c.cache[key]; !exists {
+		return
+	}
+	delete(c.cache, key)
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
+	}
+}
+
 type ResharingCache struct {
 	mu      sync.RWMutex
 	cache   map[string]*dkg.DistKeyGenerator
@@ -155,6 +174,25 @@ func (c *ResharingCache) evictIfFull() {
 		oldest := c.order[0]
 		c.order = c.order[1:]
 		delete(c.cache, oldest)
+	}
+}
+
+// Delete removes the entry for (fromRound, toRound), if present. It is a safe
+// no-op when the pair is absent, so callers may evict unconditionally.
+func (c *ResharingCache) Delete(fromRound, toRound uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := fmt.Sprintf("%d_%d", fromRound, toRound)
+	if _, exists := c.cache[key]; !exists {
+		return
+	}
+	delete(c.cache, key)
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
 	}
 }
 

--- a/store/dkg_cache_test.go
+++ b/store/dkg_cache_test.go
@@ -177,6 +177,63 @@ func TestDKGCache_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
+// TestDKGCache_Delete verifies Delete removes a present entry and is a no-op
+// when the round is absent.
+func TestDKGCache_Delete(t *testing.T) {
+	t.Parallel()
+
+	c := NewDKGCache()
+
+	// Delete on an empty cache must be a safe no-op.
+	c.Delete(1)
+
+	c.Set(1, nil)
+	c.Set(2, nil)
+
+	c.Delete(1)
+	_, ok := c.Get(1)
+	assert.False(t, ok, "round 1 should have been deleted")
+
+	_, ok = c.Get(2)
+	assert.True(t, ok, "round 2 should remain")
+
+	// Deleting an absent round leaves the rest untouched.
+	c.Delete(99)
+	_, ok = c.Get(2)
+	assert.True(t, ok, "round 2 should still remain after no-op delete")
+
+	// order must be pruned so a later insert of the same key re-tracks it.
+	c.Set(1, nil)
+	_, ok = c.Get(1)
+	assert.True(t, ok, "round 1 should be re-insertable after deletion")
+}
+
+// TestResharingCache_Delete verifies Delete removes a present pair and is a
+// no-op when the pair is absent.
+func TestResharingCache_Delete(t *testing.T) {
+	t.Parallel()
+
+	c := NewResharingDKGCache()
+
+	// Delete on an empty cache must be a safe no-op.
+	c.Delete(1, 2)
+
+	c.Set(1, 2, nil)
+	c.Set(3, 4, nil)
+
+	c.Delete(1, 2)
+	_, ok := c.Get(1, 2)
+	assert.False(t, ok, "(1,2) should have been deleted")
+
+	_, ok = c.Get(3, 4)
+	assert.True(t, ok, "(3,4) should remain")
+
+	// Deleting an absent pair is a no-op.
+	c.Delete(9, 9)
+	_, ok = c.Get(3, 4)
+	assert.True(t, ok, "(3,4) should still remain after no-op delete")
+}
+
 // =============================================================================
 // ResharingCache tests
 // =============================================================================

--- a/store/dkg_state.go
+++ b/store/dkg_state.go
@@ -31,12 +31,14 @@ type DKGState struct {
 	Justifications []dkg.Justification
 	PublicCoeffs   []kyber.Point
 
-	// FromRound indicates the original round from which this DKG state was derived.
-	// It is mainly used for resharing: when a new round is created based on the
-	// public information (pub keys, threshold, public coefficients) of a previous
-	// committee, the previous round number is stored here for recovery.
-	// For initial round (round == 1), it is set to be 0
+	// FromRound is the round this state was derived from (resharing recovery);
+	// 0 for an initial round.
 	FromRound uint32
+
+	// Emitted* hold artifacts this node produced and returned to the CL, kept so
+	// a retried RPC re-emits them instead of losing them. Not replayed on rebuild
+	// (separate from the received Deals/Responses/Justifications above).
+	EmittedResponses []dkg.Response
 }
 
 type dkgStateDisk struct {
@@ -47,6 +49,7 @@ type dkgStateDisk struct {
 	Justifications     []justificationDisk `json:"justifications,omitempty"`
 	FromRound          uint32              `json:"from_round,omitempty"`
 	PublicCoeffsBase64 []string            `json:"public_coeffs_base_64,omitempty"`
+	EmittedResponses   []dkg.Response      `json:"emitted_responses,omitempty"`
 }
 
 // justificationDisk is the JSON-serializable representation of dkg.Justification.
@@ -257,9 +260,13 @@ func (s *DKGStore) privateCoeffsPath(codeCommitmentHex string, round uint32) str
 	return filepath.Join(s.stateDir, strconv.FormatUint(uint64(round), 10), codeCommitmentHex, PrivateCoeffsFile)
 }
 
-func (s *DKGStore) AddDeals(codeCommitmentHex string, round uint32, deals []dkg.Deal) error {
+// AddProcessedDeals appends processed deals and the responses this node
+// generated for them in a single atomic write, so a retried ProcessDeals can
+// re-emit the responses from EmittedResponses.
+func (s *DKGStore) AddProcessedDeals(codeCommitmentHex string, round uint32, deals []dkg.Deal, emittedResps []dkg.Response) error {
 	return s.updateState(codeCommitmentHex, round, func(st *DKGState) {
 		st.Deals = append(st.Deals, deals...)
+		st.EmittedResponses = append(st.EmittedResponses, emittedResps...)
 	})
 }
 
@@ -282,12 +289,13 @@ func (s *DKGStore) toDisk(st *DKGState) (*dkgStateDisk, error) {
 	}
 
 	d := &dkgStateDisk{
-		Threshold:      st.Threshold,
-		Deals:          st.Deals,
-		Responses:      st.Responses,
-		Justifications: justDisk,
-		FromRound:      st.FromRound,
-		PubKeysBase64:  make([]string, len(st.PubKeys)),
+		Threshold:        st.Threshold,
+		Deals:            st.Deals,
+		Responses:        st.Responses,
+		Justifications:   justDisk,
+		FromRound:        st.FromRound,
+		EmittedResponses: st.EmittedResponses,
+		PubKeysBase64:    make([]string, len(st.PubKeys)),
 	}
 
 	for i, p := range st.PubKeys {
@@ -320,12 +328,13 @@ func (s *DKGStore) fromDisk(d *dkgStateDisk) (*DKGState, error) {
 	}
 
 	st := &DKGState{
-		Threshold:      d.Threshold,
-		Deals:          d.Deals,
-		Responses:      d.Responses,
-		Justifications: justs,
-		FromRound:      d.FromRound,
-		PubKeys:        make([]kyber.Point, len(d.PubKeysBase64)),
+		Threshold:        d.Threshold,
+		Deals:            d.Deals,
+		Responses:        d.Responses,
+		Justifications:   justs,
+		FromRound:        d.FromRound,
+		EmittedResponses: d.EmittedResponses,
+		PubKeys:          make([]kyber.Point, len(d.PubKeysBase64)),
 	}
 
 	for i, enc := range d.PubKeysBase64 {

--- a/store/dkg_state_extended_test.go
+++ b/store/dkg_state_extended_test.go
@@ -224,11 +224,11 @@ func TestSetPublicCoeffs_Overwrite(t *testing.T) {
 }
 
 // =============================================================================
-// AddDeals tests
+// AddProcessedDeals tests
 // =============================================================================
 
-// TestAddDeals_Basic verifies deals are appended to state.
-func TestAddDeals_Basic(t *testing.T) {
+// TestAddProcessedDeals_Basic verifies deals are appended to state.
+func TestAddProcessedDeals_Basic(t *testing.T) {
 	t.Parallel()
 	store := newTestDKGStore(t)
 	suite := edwards25519.NewBlakeSHA256Ed25519()
@@ -253,15 +253,15 @@ func TestAddDeals_Basic(t *testing.T) {
 		dealSlice = append(dealSlice, *d)
 	}
 
-	require.NoError(t, store.AddDeals(cc, round, dealSlice))
+	require.NoError(t, store.AddProcessedDeals(cc, round, dealSlice, nil))
 
 	st, err := store.LoadDKGState(cc, round)
 	require.NoError(t, err)
 	require.Len(t, st.Deals, len(dealSlice))
 }
 
-// TestAddDeals_Appends verifies subsequent calls append to existing deals.
-func TestAddDeals_Appends(t *testing.T) {
+// TestAddProcessedDeals_Appends verifies subsequent calls append to existing deals.
+func TestAddProcessedDeals_Appends(t *testing.T) {
 	t.Parallel()
 	store := newTestDKGStore(t)
 	suite := edwards25519.NewBlakeSHA256Ed25519()
@@ -286,8 +286,8 @@ func TestAddDeals_Appends(t *testing.T) {
 		dealSlice = append(dealSlice, *d)
 	}
 
-	require.NoError(t, store.AddDeals(cc, round, dealSlice))
-	require.NoError(t, store.AddDeals(cc, round, dealSlice))
+	require.NoError(t, store.AddProcessedDeals(cc, round, dealSlice, nil))
+	require.NoError(t, store.AddProcessedDeals(cc, round, dealSlice, nil))
 
 	st, err := store.LoadDKGState(cc, round)
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

When a story→kernel `ProcessDeals` call times out, the kernel keeps processing and generates the verifier's responses, but they die with the disconnected call. The story-side retry then hits the idempotent-dedup branch, which returned **nothing** — so the verifier's approvals are lost network-wide. `GenerateDeals` is retry-safe (it regenerates from sealed coeffs); `ProcessDeals` was not.

## Fix

- Persist each generated response with its deal in one atomic write (`AddProcessedDeals` into a new `EmittedResponses` field, kept separate from peers' `Responses` so replay/rebuild are unaffected). On a retried deal kyber already absorbed, re-emit the stored response instead of dropping it.
- Serialize the DKG-mutating RPCs (`ProcessDeals`/`ProcessResponses`/`ProcessJustification`) per round with a shared `dkgMutationMu`: a client timeout leaves the abandoned handler running, and its retry (or an adjacent RPC) must not mutate the shared, unsynchronized `DistKeyGenerator` concurrently. Held across process+persist so the retry re-emits deterministically.

## Tests

- `TestApplyDeals_ReemitsStoredResponsesOnResubmit`
- `TestApplyDeals_EmittedResponsesStoredSeparately`
- `TestApplyDeals_MissingEmittedResponsesSilentlySkips`
- `TestProcessDeals_ConcurrentRoundSerialized` (`-race`)

issue: #84