### PR TITLE
fix(service): sign resharing justifications before returning them to the CL

### DIFF
--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -381,6 +381,13 @@ func (s *DKGServer) signJustificationIfNeeded(
 		return false
 	}
 
+	// Confirm this node signed a resharing justification with its prev-committee key.
+	log.WithFields(log.Fields{
+		"round":               round,
+		"code_commitment":     codeCommitmentHex,
+		"justification_index": j.Index,
+	}).Info("signed resharing justification")
+
 	return true
 }
 

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -11,7 +11,11 @@ import (
 	"github.com/piplabs/story-kernel/types"
 	pb "github.com/piplabs/story-kernel/types/pb/v0"
 
+	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/group/edwards25519"
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+	vss "go.dedis.ch/kyber/v4/share/vss/pedersen"
+	"go.dedis.ch/kyber/v4/sign/schnorr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -56,6 +60,10 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 	// in the NEW committee, so the bounds diverge.
 	var dealerCount, complainerCount int
 
+	// latestActiveRound is the prev (dealer) committee round whose sealed key signs
+	// resharing justifications. Only set for resharing.
+	var latestActiveRound uint32
+
 	var distKeyGens []*dkg.DistKeyGenerator
 	if !req.GetIsResharing() {
 		dealerCount = len(rc.SortedPubKeys)
@@ -85,6 +93,7 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 
 		dealerCount = int(latest.GetTotal())    // OLD committee
 		complainerCount = len(rc.SortedPubKeys) // NEW committee
+		latestActiveRound = latest.GetRound()   // signs resharing justifications
 
 		prevDistKeyGen, err := s.GetResharingPrevDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys, latest)
 		if err != nil {
@@ -120,18 +129,77 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 	// proto-conversion failure AND a generator failure happen on the same
 	// item; the CL deduplicates via a per-batch map keyed by (Index, inner
 	// Index) so we don't bother deduping here.
+	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
+	// RPCs for this round (see dkgMutationMu). Held across process+persist so a
+	// retry sees a fully persisted state and re-emits its emitted justifications
+	// deterministically. Lock order dkgMutationMu -> stateMu stays one-directional.
+	mu := s.getDKGMutationMu(req.GetRound())
+	mu.Lock()
+	justifications, processed, rejected, err := s.applyResponses(
+		distKeyGens, req.GetIsResharing(), codeCommitmentHex, req.GetRound(),
+		latestActiveRound, dealerCount, complainerCount, req.GetResponses(),
+	)
+	mu.Unlock()
+	if err != nil {
+		log.Errorf("failed to add processed responses to the DKG state: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to add processed responses to the DKG state")
+	}
+
+	log.WithFields(log.Fields{
+		"code_commitment": codeCommitmentHex,
+		"round":           req.GetRound(),
+		"processed":       processed,
+		"rejected":        len(rejected),
+	}).Info("Processed responses")
+
+	return &pb.ProcessResponsesResponse{
+		Justifications:    justifications,
+		RejectedResponses: rejected,
+	}, nil
+}
+
+// applyResponses runs each response through the configured generators, signs any
+// resharing justification kyber left unsigned, persists the processed responses
+// with the justifications this node generated (atomically), and returns the
+// justifications to forward, the count of responses persisted, and the rejected
+// ones. Mirrors applyDeals (process+persist in one call) so ProcessResponses can
+// hold the mutex across both with a single Lock/Unlock. Extracted so the signing
+// wiring is testable without the enclave-gated RPC entry point.
+func (s *DKGServer) applyResponses(
+	distKeyGens []*dkg.DistKeyGenerator,
+	isResharing bool,
+	codeCommitmentHex string,
+	round uint32,
+	latestActiveRound uint32,
+	dealerCount, complainerCount int,
+	reqResponses []*pb.Response,
+) ([]*pb.Justification, int, []*pb.Response, error) {
 	var (
 		justifications []*pb.Justification
 		resps          []dkg.Response
+		emittedJusts   []dkg.Justification
 		rejected       []*pb.Response
 	)
 
-	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
-	// RPCs for this round (see dkgMutationMu). Persist runs after the loop under
-	// its own store lock, so only the kyber mutation needs covering here.
-	mu := s.getDKGMutationMu(req.GetRound())
-	mu.Lock()
-	for _, response := range req.GetResponses() {
+	// Dealer key that signs resharing justifications, loaded at most once and
+	// only when a justification actually needs it (only a prev-committee dealer
+	// holds it).
+	dealerKey := &lazy[kyber.Scalar]{load: func() (kyber.Scalar, error) {
+		return s.DKGStore.LoadSealedEd25519Key(codeCommitmentHex, latestActiveRound)
+	}}
+
+	// EmittedJustifications, loaded at most once and only for a retried complaint.
+	storedJusts := &lazy[[]dkg.Justification]{load: func() ([]dkg.Justification, error) {
+		st, err := s.DKGStore.LoadDKGState(codeCommitmentHex, round)
+		if err != nil {
+			return nil, err
+		}
+
+		return st.EmittedJustifications, nil
+	}}
+
+	for _, response := range reqResponses {
 		resp := types.ConvertToVSSResp(response)
 
 		// Defence in depth: bounds-check the dealer AND complainer indices
@@ -151,66 +219,37 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 			continue
 		}
 
-		// processed: at least one DistKeyGenerator applied the response (real
-		// success or idempotent re-submission). In resharing (prev + next),
-		// only one generator typically owns a given response — the others
-		// may return real errors ("unknown dealer" etc.) without indicating
-		// rejection. Reject only when EVERY generator returned a real
-		// (non-idempotent) error.
-		processed := false
-		for _, distKeyGen := range distKeyGens {
-			j, err := distKeyGen.ProcessResponse(resp)
-			if err != nil {
-				// Log only indices to match the dealing/justification handlers'
-				// hygiene; avoids dumping the full VSSResponse struct into logs
-				// in case future kyber/proto evolution adds fields not safe to
-				// expose verbatim.
+		res := s.processResponse(distKeyGens, resp, isResharing, dealerKey, round, codeCommitmentHex)
+		justifications = append(justifications, res.pbJusts...)
+		emittedJusts = append(emittedJusts, res.emitted...)
+
+		if shouldReEmitJustification(res, resp) {
+			pbJust, rerr := reEmitJustification(storedJusts, resp)
+			switch {
+			case rerr != nil:
+				// Cannot fail the RPC (justifications already converted); treat as none-stored.
 				log.WithFields(log.Fields{
-					"round":            req.GetRound(),
+					"round":           round,
+					"code_commitment": codeCommitmentHex,
+				}).Errorf("failed to re-emit stored justification: %v", rerr)
+			case pbJust != nil:
+				justifications = append(justifications, pbJust)
+			default:
+				// Normal on any node that is not the complained-of dealer: a
+				// complaint is broadcast to everyone but only the dealer stores a
+				// justification for it, so most nodes have nothing to re-emit. The
+				// one problematic case (the dealer's persist failed) is already
+				// logged at Error where AddProcessedResponses fails, so this is Debug.
+				log.WithFields(log.Fields{
+					"round":            round,
 					"code_commitment":  codeCommitmentHex,
-					"dealer_index":     response.GetIndex(),
-					"complainer_index": response.GetVssResponse().GetIndex(),
-				}).Errorf("failed to process the response: %v", err)
-
-				if isAlreadyProcessedErr(err) {
-					processed = true
-				}
-
-				continue
+					"dealer_index":     resp.Index,
+					"complainer_index": resp.Response.Index,
+				}).Debug("response already processed with no stored justification to re-emit; skipping")
 			}
-
-			processed = true
-
-			if j == nil {
-				continue
-			}
-
-			justification, convErr := types.ConvertToJustificationProto(j)
-			if convErr != nil {
-				// kyber already absorbed `resp`; retry would hit the idempotent
-				// guard (j == nil) and never re-derive the justification.
-				// Putting `response` in rejected_responses would mislead the CL
-				// into retrying a permanently-lost artifact, and failing the
-				// whole RPC would also discard valid justifications already
-				// converted in this batch. Drop only this justification — the
-				// response itself is still added to resps below so kyber's
-				// in-memory state and DKGStore stay consistent.
-				// (Effectively unreachable on Ed25519 — kept for future suite changes.)
-				// Log only the index to avoid leaking SecShare from PlainDeal.
-				log.WithFields(log.Fields{
-					"round":               req.GetRound(),
-					"code_commitment":     codeCommitmentHex,
-					"justification_index": j.Index,
-				}).Errorf("failed to convert generated justification to proto; "+
-					"justification dropped: %v", convErr)
-
-				continue
-			}
-
-			justifications = append(justifications, justification)
 		}
 
-		if !processed {
+		if !res.processed {
 			rejected = append(rejected, response)
 
 			continue
@@ -218,27 +257,162 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 
 		resps = append(resps, *resp)
 	}
-	mu.Unlock()
 
 	if len(resps) > 0 {
-		if err := s.DKGStore.AddResponses(codeCommitmentHex, req.GetRound(), resps); err != nil {
-			log.Errorf("failed to add responses to the DKG state: %v", err)
-
-			return nil, status.Errorf(codes.Internal, "failed to add responses to the DKG state")
+		if err := s.DKGStore.AddProcessedResponses(codeCommitmentHex, round, resps, emittedJusts); err != nil {
+			return nil, 0, nil, err
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"code_commitment": codeCommitmentHex,
-		"round":           req.GetRound(),
-		"processed":       len(resps),
-		"rejected":        len(rejected),
-	}).Info("Processed responses")
+	return justifications, len(resps), rejected, nil
+}
 
-	return &pb.ProcessResponsesResponse{
-		Justifications:    justifications,
-		RejectedResponses: rejected,
-	}, nil
+// responseResult summarizes processing one response against every generator.
+type responseResult struct {
+	processed  bool // at least one generator accepted it (real success or idempotent)
+	idempotent bool // at least one generator reported it already absorbed (a retry)
+	freshJust  bool // kyber (re-)generated a justification this call
+	pbJusts    []*pb.Justification
+	emitted    []dkg.Justification // signed justifications to persist
+}
+
+// processResponse runs resp through every generator, signs any fresh resharing
+// justification, and reports the outcome. Reject only when EVERY generator
+// returns a real (non-idempotent) error; in resharing (prev+next) only one
+// generator typically owns a given response.
+func (s *DKGServer) processResponse(
+	distKeyGens []*dkg.DistKeyGenerator,
+	resp *dkg.Response,
+	isResharing bool,
+	dealerKey *lazy[kyber.Scalar],
+	round uint32,
+	codeCommitmentHex string,
+) responseResult {
+	var complainerIdx uint32
+	if resp.Response != nil {
+		complainerIdx = resp.Response.Index
+	}
+
+	var res responseResult
+	for _, distKeyGen := range distKeyGens {
+		j, err := distKeyGen.ProcessResponse(resp)
+		if err != nil {
+			// Log only indices, never the full VSSResponse struct.
+			log.WithFields(log.Fields{
+				"round":            round,
+				"code_commitment":  codeCommitmentHex,
+				"dealer_index":     resp.Index,
+				"complainer_index": complainerIdx,
+			}).Errorf("failed to process the response: %v", err)
+
+			if isAlreadyProcessedErr(err) {
+				res.processed = true
+				res.idempotent = true
+			}
+
+			continue
+		}
+
+		res.processed = true
+		if j == nil {
+			continue
+		}
+
+		if !s.signJustificationIfNeeded(isResharing, dealerKey, j, round, codeCommitmentHex) {
+			continue
+		}
+
+		pbJust, convErr := types.ConvertToJustificationProto(j)
+		if convErr != nil {
+			// Drop only this justification (unreachable on Ed25519); the response
+			// still flows to resps so kyber and the store stay consistent. Log
+			// only the index to avoid leaking SecShare.
+			log.WithFields(log.Fields{
+				"round":               round,
+				"code_commitment":     codeCommitmentHex,
+				"justification_index": j.Index,
+			}).Errorf("failed to convert generated justification to proto; justification dropped: %v", convErr)
+
+			continue
+		}
+
+		res.pbJusts = append(res.pbJusts, pbJust)
+		// Keep the kyber form so ProcessResponses persists it with the response.
+		res.emitted = append(res.emitted, *j)
+		res.freshJust = true
+	}
+
+	return res
+}
+
+// signJustificationIfNeeded signs an unsigned resharing justification with the
+// lazily-loaded dealer key. It returns false when the justification must be
+// dropped (key load or signing failed) rather than forwarded unsigned, which the
+// CL would reject. Initial-DKG justifications arrive kyber-signed and are left
+// untouched.
+func (s *DKGServer) signJustificationIfNeeded(
+	isResharing bool,
+	dealerKey *lazy[kyber.Scalar],
+	j *dkg.Justification,
+	round uint32,
+	codeCommitmentHex string,
+) bool {
+	if !isResharing || len(j.Justification.Signature) != 0 {
+		return true
+	}
+
+	key, err := dealerKey.Get()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"round":           round,
+			"code_commitment": codeCommitmentHex,
+		}).Errorf("failed to load dealer key to sign resharing justification; dropping: %v", err)
+
+		return false
+	}
+
+	if err := signResharingJustification(s.Suite, key, j); err != nil {
+		log.WithFields(log.Fields{
+			"round":               round,
+			"code_commitment":     codeCommitmentHex,
+			"justification_index": j.Index,
+		}).Errorf("failed to sign resharing justification; dropping: %v", err)
+
+		return false
+	}
+
+	return true
+}
+
+// shouldReEmitJustification reports whether a retried response needs its
+// justification recovered from storage. Unlike deals — where a response is either
+// freshly generated or re-emitted — a response runs through prev+next generators,
+// so it can be idempotent on one and produce a fresh justification on another;
+// re-emit only when it was idempotent AND no fresh justification was produced. And
+// only complaints ever produce justifications, so approvals are skipped (which also
+// keeps the not-found warning meaningful).
+func shouldReEmitJustification(res responseResult, resp *dkg.Response) bool {
+	return res.idempotent && !res.freshJust &&
+		resp.Response != nil && resp.Response.Status == vss.StatusComplaint
+}
+
+// reEmitJustification returns the signed justification this node persisted for
+// the complaint in resp so a retried response recovers it, or nil if none was
+// stored (keyed by dealer + complainer index, at most one per pair).
+func reEmitJustification(stored *lazy[[]dkg.Justification], resp *dkg.Response) (*pb.Justification, error) {
+	emitted, err := stored.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range emitted {
+		ej := &emitted[i]
+		if ej.Index == resp.Index && ej.Justification.Index == resp.Response.Index {
+			return types.ConvertToJustificationProto(ej)
+		}
+	}
+
+	return nil, nil
 }
 
 func validateProcessResponsesRequest(req *pb.ProcessResponsesRequest) error {
@@ -253,6 +427,33 @@ func validateProcessResponsesRequest(req *pb.ProcessResponsesRequest) error {
 	if len(req.GetResponses()) == 0 {
 		return errors.New("empty responses to process")
 	}
+
+	return nil
+}
+
+// signResharingJustification Schnorr-signs the inner vss.Justification with the
+// dealer's longterm key when kyber left it unsigned. It signs the exact bytes the
+// CL verifies (j.Justification.Hash(suite)) and no-ops when a signature is already
+// present, so the initial-DKG path (kyber-signed) is never overwritten.
+//
+// Why this is done manually: on the resharing path kyber's processResharingResponse
+// (go.dedis.ch/kyber/v4@v4.0.0-pre2, share/dkg/pedersen/dkg.go) builds the
+// justification WITHOUT a Signature — unlike the initial-DKG path, where
+// vss.Dealer.ProcessResponse signs it internally via schnorr.Sign. This mirrors
+// that signed path exactly (same key, same j.Hash). Kyber fixed this in v4.0.2 by
+// rewriting justifications to a uniformly-signed JustificationBundle (d.sign), so
+// once the kernel upgrades kyber past pre2 this manual signing can be removed.
+func signResharingJustification(suite *edwards25519.SuiteEd25519, longterm kyber.Scalar, j *dkg.Justification) error {
+	if j == nil || j.Justification == nil || len(j.Justification.Signature) != 0 {
+		return nil
+	}
+
+	sig, err := schnorr.Sign(suite, longterm, j.Justification.Hash(suite))
+	if err != nil {
+		return err
+	}
+
+	j.Justification.Signature = sig
 
 	return nil
 }

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -219,7 +219,15 @@ func (s *DKGServer) applyResponses(
 			continue
 		}
 
-		res := s.processResponse(distKeyGens, resp, isResharing, dealerKey, round, codeCommitmentHex)
+		res, err := s.processResponse(distKeyGens, resp, isResharing, dealerKey, round, codeCommitmentHex)
+		if err != nil {
+			// Transient dealer-key-load failure. Return before AddProcessedResponses
+			// so nothing is persisted for this batch; the CL retries the whole call
+			// and the justification is re-generated and signed once the key is
+			// available (kyber's resharing-own-deal path re-emits on every call, so
+			// the in-memory generator mutation from this call is not lost on retry).
+			return nil, 0, nil, err
+		}
 		justifications = append(justifications, res.pbJusts...)
 		emittedJusts = append(emittedJusts, res.emitted...)
 
@@ -279,7 +287,9 @@ type responseResult struct {
 // processResponse runs resp through every generator, signs any fresh resharing
 // justification, and reports the outcome. Reject only when EVERY generator
 // returns a real (non-idempotent) error; in resharing (prev+next) only one
-// generator typically owns a given response.
+// generator typically owns a given response. Returns a non-nil error only for a
+// transient dealer-key-load failure, which must abort the batch so the CL retries
+// (see signJustificationIfNeeded); all other drops are folded into the result.
 func (s *DKGServer) processResponse(
 	distKeyGens []*dkg.DistKeyGenerator,
 	resp *dkg.Response,
@@ -287,7 +297,7 @@ func (s *DKGServer) processResponse(
 	dealerKey *lazy[kyber.Scalar],
 	round uint32,
 	codeCommitmentHex string,
-) responseResult {
+) (responseResult, error) {
 	var complainerIdx uint32
 	if resp.Response != nil {
 		complainerIdx = resp.Response.Index
@@ -318,7 +328,13 @@ func (s *DKGServer) processResponse(
 			continue
 		}
 
-		if !s.signJustificationIfNeeded(isResharing, dealerKey, j, round, codeCommitmentHex) {
+		signed, err := s.signJustificationIfNeeded(isResharing, dealerKey, j, round, codeCommitmentHex)
+		if err != nil {
+			// Transient key-load failure: abort so the caller returns an error and
+			// the CL retries. Nothing persisted yet, so the retry re-generates this.
+			return res, err
+		}
+		if !signed {
 			continue
 		}
 
@@ -342,43 +358,46 @@ func (s *DKGServer) processResponse(
 		res.freshJust = true
 	}
 
-	return res
+	return res, nil
 }
 
 // signJustificationIfNeeded signs an unsigned resharing justification with the
-// lazily-loaded dealer key. It returns false when the justification must be
-// dropped (key load or signing failed) rather than forwarded unsigned, which the
-// CL would reject. Initial-DKG justifications arrive kyber-signed and are left
-// untouched.
+// lazily-loaded dealer key and reports whether it was signed. A key-LOAD failure is
+// transient (sealer/TEE momentarily unavailable): it returns an error so the CL retries
+// and re-signs once the key loads. A signing failure on a loaded key is deterministic,
+// so it drops the justification (false, nil) instead of forwarding it unsigned.
+// Initial-DKG justifications arrive kyber-signed and are left untouched.
 func (s *DKGServer) signJustificationIfNeeded(
 	isResharing bool,
 	dealerKey *lazy[kyber.Scalar],
 	j *dkg.Justification,
 	round uint32,
 	codeCommitmentHex string,
-) bool {
+) (bool, error) {
 	if !isResharing || len(j.Justification.Signature) != 0 {
-		return true
+		return true, nil
 	}
 
 	key, err := dealerKey.Get()
 	if err != nil {
+		// Transient: surface so the CL retries instead of dropping the justification.
 		log.WithFields(log.Fields{
 			"round":           round,
 			"code_commitment": codeCommitmentHex,
-		}).Errorf("failed to load dealer key to sign resharing justification; dropping: %v", err)
+		}).Errorf("failed to load dealer key to sign resharing justification; retrying: %v", err)
 
-		return false
+		return false, errors.Wrap(err, "load dealer key to sign resharing justification")
 	}
 
 	if err := signResharingJustification(s.Suite, key, j); err != nil {
+		// Deterministic: retrying will not help, so drop this justification.
 		log.WithFields(log.Fields{
 			"round":               round,
 			"code_commitment":     codeCommitmentHex,
 			"justification_index": j.Index,
 		}).Errorf("failed to sign resharing justification; dropping: %v", err)
 
-		return false
+		return false, nil
 	}
 
 	// Confirm this node signed a resharing justification with its prev-committee key.
@@ -388,7 +407,7 @@ func (s *DKGServer) signJustificationIfNeeded(
 		"justification_index": j.Index,
 	}).Info("signed resharing justification")
 
-	return true
+	return true, nil
 }
 
 // shouldReEmitJustification reports whether a retried response needs its

--- a/service/dkg_process_responses_test.go
+++ b/service/dkg_process_responses_test.go
@@ -1,11 +1,22 @@
 package service
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/group/edwards25519"
+	"go.dedis.ch/kyber/v4/share"
+	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+	vss "go.dedis.ch/kyber/v4/share/vss/pedersen"
+	"go.dedis.ch/kyber/v4/sign/schnorr"
+
+	"github.com/piplabs/story-kernel/store"
+	"github.com/piplabs/story-kernel/types"
 	pb "github.com/piplabs/story-kernel/types/pb/v0"
 )
 
@@ -155,4 +166,558 @@ func TestValidateProcessResponsesRequest_TableDriven(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSignResharingJustification_ResharingSignsAndVerifies proves the fix for
+// issue #85: kyber's processResharingResponse returns an UNSIGNED justification
+// (dealer key rotated out of the new committee, so newPresent=false), and
+// signResharingJustification signs it with the dealer's prev-round key over the
+// exact hash the CL verifies against the dealer's prev-round dkgPubKey.
+func TestSignResharingJustification_ResharingSignsAndVerifies(t *testing.T) {
+	t.Parallel()
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const nOld, threshold = 3, 2
+	c := runCertifiedInitialDKG(t, nOld, threshold)
+
+	// New committee uses fresh (rotated) keys, so every old dealer has
+	// newPresent=false and routes responses through processResharingResponse.
+	const nNew = 3
+	newLong := make([]kyber.Scalar, nNew)
+	newPubs := make([]kyber.Point, nNew)
+	for i := 0; i < nNew; i++ {
+		newLong[i] = suite.Scalar().Pick(suite.RandomStream())
+		newPubs[i] = suite.Point().Mul(newLong[i], nil)
+	}
+
+	const dealerIdx, verifierIdx = 0, 0
+
+	share, err := c.gens[dealerIdx].DistKeyShare()
+	require.NoError(t, err)
+
+	prevHandler, err := dkg.NewDistKeyHandler(&dkg.Config{
+		Suite:        suite,
+		Longterm:     c.longterms[dealerIdx],
+		OldNodes:     c.pubs,
+		NewNodes:     newPubs,
+		Share:        share,
+		Threshold:    threshold,
+		OldThreshold: threshold,
+	})
+	require.NoError(t, err)
+
+	// Dealer emits its resharing deals, as in production, before handling responses.
+	_, err = prevHandler.Deals()
+	require.NoError(t, err)
+
+	// Craft a StatusComplaint from new-committee verifier 0 against the dealer's own
+	// deal (outer Index = dealer's old index). The dealer's fresh empty aggregator
+	// has no sessionID yet, so it only checks the verifier's Schnorr signature — the
+	// cheapest way to drive processResharingResponse to emit an unsigned justification.
+	vresp := &vss.Response{Index: verifierIdx, Status: vss.StatusComplaint}
+	vresp.Signature, err = schnorr.Sign(suite, newLong[verifierIdx], vresp.Hash(suite))
+	require.NoError(t, err)
+
+	j, err := prevHandler.ProcessResponse(&dkg.Response{Index: dealerIdx, Response: vresp})
+	require.NoError(t, err)
+	require.NotNil(t, j)
+	require.Empty(t, j.Justification.Signature, "kyber must leave the resharing justification unsigned (the bug)")
+
+	// Apply the fix with the dealer's prev-round longterm key.
+	require.NoError(t, signResharingJustification(suite, c.longterms[dealerIdx], j))
+	require.NotEmpty(t, j.Justification.Signature)
+
+	// Verify exactly as the CL does: convert to proto, reconstruct, hash, verify
+	// against the dealer's prev-round dkgPubKey.
+	pbJ, err := types.ConvertToJustificationProto(j)
+	require.NoError(t, err)
+	require.NotEmpty(t, pbJ.GetVssJustification().GetSignature(), "signature must propagate into the proto field")
+
+	kyberJ, err := types.ConvertToJustification(pbJ)
+	require.NoError(t, err)
+	require.NoError(t, schnorr.Verify(suite, c.pubs[dealerIdx], kyberJ.Justification.Hash(suite), kyberJ.Justification.Signature))
+}
+
+// verifyJustificationLikeStoryClient replicates the story chain's
+// verifyJustificationSignature (client/x/dkg/keeper/dkg_justification.go): it
+// reconstructs the kyber vss.Justification from the proto fields — NOT via the
+// kernel's own ConvertToJustification — computes the canonical hash, and Schnorr-
+// verifies against the dealer pubkey. This pins that a justification the kernel
+// signs passes the EXACT on-chain verification path, catching any divergence
+// between the kernel converter and the CL's manual reconstruction.
+func verifyJustificationLikeStoryClient(suite *edwards25519.SuiteEd25519, pbJ *pb.Justification, dealerPub kyber.Point) error {
+	vssJ := pbJ.GetVssJustification()
+	if vssJ == nil {
+		return errors.New("nil VSSJustification")
+	}
+	plainDeal := vssJ.GetPlainDeal()
+	if plainDeal == nil {
+		return errors.New("nil PlainDeal")
+	}
+	secShare := plainDeal.GetSecShare()
+	if secShare == nil || secShare.GetV() == nil {
+		return errors.New("nil SecShare or scalar value")
+	}
+	if len(vssJ.GetSignature()) == 0 {
+		return errors.New("empty justification signature")
+	}
+
+	shareScalar := suite.Scalar()
+	if err := shareScalar.UnmarshalBinary(secShare.GetV().GetData()); err != nil {
+		return errors.Wrap(err, "unmarshal share scalar")
+	}
+
+	commitments := make([]kyber.Point, 0, len(plainDeal.GetCommitments()))
+	for _, cc := range plainDeal.GetCommitments() {
+		p := suite.Point()
+		if err := p.UnmarshalBinary(cc.GetData()); err != nil {
+			return errors.Wrap(err, "unmarshal commitment point")
+		}
+		commitments = append(commitments, p)
+	}
+
+	kyberJust := &vss.Justification{
+		SessionID: vssJ.GetSessionId(),
+		Index:     vssJ.GetIndex(),
+		Deal: &vss.Deal{
+			SessionID: plainDeal.GetSessionId(),
+			SecShare: &share.PriShare{
+				I: int(secShare.GetI()),
+				V: shareScalar,
+			},
+			T:           plainDeal.GetThreshold(),
+			Commitments: commitments,
+		},
+		Signature: vssJ.GetSignature(),
+	}
+
+	return schnorr.Verify(suite, dealerPub, kyberJust.Hash(suite), kyberJust.Signature)
+}
+
+// TestSignResharingJustification_PassesStoryClientVerification proves a kernel-
+// signed resharing justification verifies under the story chain's exact
+// reconstruction+verify logic (not the kernel's own converter), and that the
+// check rejects a tampered signature.
+func TestSignResharingJustification_PassesStoryClientVerification(t *testing.T) {
+	t.Parallel()
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const nOld, threshold, nNew = 3, 2, 3
+	c := runCertifiedInitialDKG(t, nOld, threshold)
+
+	newLong := make([]kyber.Scalar, nNew)
+	newPubs := make([]kyber.Point, nNew)
+	for i := 0; i < nNew; i++ {
+		newLong[i] = suite.Scalar().Pick(suite.RandomStream())
+		newPubs[i] = suite.Point().Mul(newLong[i], nil)
+	}
+
+	const dealerIdx, verifierIdx = 0, 0
+
+	share0, err := c.gens[dealerIdx].DistKeyShare()
+	require.NoError(t, err)
+
+	prevHandler, err := dkg.NewDistKeyHandler(&dkg.Config{
+		Suite:        suite,
+		Longterm:     c.longterms[dealerIdx],
+		OldNodes:     c.pubs,
+		NewNodes:     newPubs,
+		Share:        share0,
+		Threshold:    threshold,
+		OldThreshold: threshold,
+	})
+	require.NoError(t, err)
+	_, err = prevHandler.Deals()
+	require.NoError(t, err)
+
+	vresp := &vss.Response{Index: verifierIdx, Status: vss.StatusComplaint}
+	vresp.Signature, err = schnorr.Sign(suite, newLong[verifierIdx], vresp.Hash(suite))
+	require.NoError(t, err)
+
+	j, err := prevHandler.ProcessResponse(&dkg.Response{Index: dealerIdx, Response: vresp})
+	require.NoError(t, err)
+	require.NotNil(t, j)
+
+	require.NoError(t, signResharingJustification(suite, c.longterms[dealerIdx], j))
+
+	pbJ, err := types.ConvertToJustificationProto(j)
+	require.NoError(t, err)
+
+	// The dealer pubkey the CL looks up is the dealer's prev-round dkgPubKey.
+	require.NoError(t, verifyJustificationLikeStoryClient(suite, pbJ, c.pubs[dealerIdx]),
+		"kernel-signed justification must pass the story client's exact verification")
+
+	// Negative control: a flipped signature byte must fail the same path.
+	tampered, err := types.ConvertToJustificationProto(j)
+	require.NoError(t, err)
+	tampered.GetVssJustification().GetSignature()[0] ^= 0xFF
+	require.Error(t, verifyJustificationLikeStoryClient(suite, tampered, c.pubs[dealerIdx]))
+}
+
+// TestSignResharingJustification_InitialPathUntouched confirms the initial-DKG
+// path — where kyber already Schnorr-signs the justification — is not re-signed
+// or overwritten, and the signature still verifies.
+func TestSignResharingJustification_InitialPathUntouched(t *testing.T) {
+	t.Parallel()
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const n, threshold = 3, 2
+
+	long := make([]kyber.Scalar, n)
+	pubs := make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		long[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(long[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, long[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	const dealerIdx, verifierIdx = 0, 1
+
+	deals, err := gens[dealerIdx].Deals()
+	require.NoError(t, err)
+
+	// Verifier processes the dealer's honest deal -> approval carrying the correct
+	// sessionID and a valid signature; flip it to a complaint and re-sign so the
+	// dealer's non-resharing path produces a kyber-SIGNED justification.
+	resp, err := gens[verifierIdx].ProcessDeal(deals[verifierIdx])
+	require.NoError(t, err)
+	require.Equal(t, vss.StatusApproval, resp.Response.Status)
+
+	resp.Response.Status = vss.StatusComplaint
+	resp.Response.Signature, err = schnorr.Sign(suite, long[verifierIdx], resp.Response.Hash(suite))
+	require.NoError(t, err)
+
+	j, err := gens[dealerIdx].ProcessResponse(resp)
+	require.NoError(t, err)
+	require.NotNil(t, j)
+	require.NotEmpty(t, j.Justification.Signature, "kyber must sign the initial-DKG justification")
+
+	// The fix must be a no-op here: same signature bytes, still valid.
+	before := append([]byte(nil), j.Justification.Signature...)
+	require.NoError(t, signResharingJustification(suite, long[dealerIdx], j))
+	assert.Equal(t, before, j.Justification.Signature, "initial-DKG signature must not be re-signed/overwritten")
+	require.NoError(t, schnorr.Verify(suite, pubs[dealerIdx], j.Justification.Hash(suite), j.Justification.Signature))
+}
+
+// buildUnsignedResharingJustification constructs a resharing dealer whose key
+// rotated out of the new committee (newPresent=false) and the crafted complaint
+// pb.Response that drives kyber to emit an UNSIGNED justification — the exact
+// shape applyResponses must sign. Mirrors the construction in
+// TestSignResharingJustification_ResharingSignsAndVerifies but returns the
+// pieces needed to drive applyResponses end to end.
+func buildUnsignedResharingJustification(t *testing.T) (
+	suite *edwards25519.SuiteEd25519,
+	c *certifiedDKG,
+	dealer *dkg.DistKeyGenerator,
+	resp *pb.Response,
+	dealerIdx, dealerCount, complainerCount int,
+) {
+	t.Helper()
+
+	suite = edwards25519.NewBlakeSHA256Ed25519()
+
+	const nOld, nNew, threshold = 3, 3, 2
+	c = runCertifiedInitialDKG(t, nOld, threshold)
+
+	// New committee uses fresh (rotated) keys, so every old dealer has
+	// newPresent=false and routes responses through processResharingResponse.
+	newLong := make([]kyber.Scalar, nNew)
+	newPubs := make([]kyber.Point, nNew)
+	for i := 0; i < nNew; i++ {
+		newLong[i] = suite.Scalar().Pick(suite.RandomStream())
+		newPubs[i] = suite.Point().Mul(newLong[i], nil)
+	}
+
+	dealerIdx = 0
+	const verifierIdx = 0
+
+	share, err := c.gens[dealerIdx].DistKeyShare()
+	require.NoError(t, err)
+
+	dealer, err = dkg.NewDistKeyHandler(&dkg.Config{
+		Suite:        suite,
+		Longterm:     c.longterms[dealerIdx],
+		OldNodes:     c.pubs,
+		NewNodes:     newPubs,
+		Share:        share,
+		Threshold:    threshold,
+		OldThreshold: threshold,
+	})
+	require.NoError(t, err)
+
+	// Dealer emits its resharing deals, as in production, before handling responses.
+	_, err = dealer.Deals()
+	require.NoError(t, err)
+
+	// Crafted StatusComplaint from new-committee verifier 0 against the dealer's own
+	// deal: the dealer's fresh aggregator has no sessionID yet, so it only checks the
+	// verifier's Schnorr signature — the cheapest way to emit an unsigned justification.
+	vresp := &vss.Response{Index: verifierIdx, Status: vss.StatusComplaint}
+	vresp.Signature, err = schnorr.Sign(suite, newLong[verifierIdx], vresp.Hash(suite))
+	require.NoError(t, err)
+
+	resp = types.ConvertToRespProto(&dkg.Response{Index: uint32(dealerIdx), Response: vresp})
+
+	return suite, c, dealer, resp, dealerIdx, nOld, nNew
+}
+
+// newPlaintextDKGStore returns a real DKGStore backed by the plaintext sealer, so
+// applyResponses' lazy LoadSealedEd25519Key wiring runs against real disk I/O.
+func newPlaintextDKGStore(t *testing.T, suite *edwards25519.SuiteEd25519) *store.DKGStore {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	return store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		suite,
+		upgradePlaintextSealer{},
+	)
+}
+
+// TestApplyResponses_ResharingJustificationSignedViaWiring drives applyResponses
+// through the full signing path (ProcessResponse → lazy dealer-key load → sign →
+// ConvertToJustificationProto) and asserts the forwarded justification carries a
+// signature that verifies against the dealer's prev-round dkgPubKey — proving the
+// wiring, not just the isolated signResharingJustification helper, works.
+func TestApplyResponses_ResharingJustificationSignedViaWiring(t *testing.T) {
+	t.Parallel()
+
+	suite, c, dealer, resp, dealerIdx, dealerCount, complainerCount := buildUnsignedResharingJustification(t)
+
+	const (
+		cc          = "cc-apply-responses-signed"
+		round       = uint32(5)
+		dealerRound = uint32(4)
+	)
+
+	st := newPlaintextDKGStore(t, suite)
+
+	// Seal the dealer's prev-round key under dealerRound so the lazy load succeeds.
+	dealerBz, err := c.longterms[dealerIdx].MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, dealerRound, dealerBz))
+
+	s := &DKGServer{Suite: suite, DKGStore: st}
+
+	justs, processed, rejected, err := s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, true, cc, round, dealerRound,
+		dealerCount, complainerCount, []*pb.Response{resp},
+	)
+	require.NoError(t, err)
+
+	require.Empty(t, rejected)
+	require.Equal(t, 1, processed, "the processed response must be persisted")
+	require.Len(t, justs, 1, "the signed justification must be forwarded")
+
+	sig := justs[0].GetVssJustification().GetSignature()
+	require.NotEmpty(t, sig, "the wiring must sign the resharing justification")
+
+	// Verify exactly as the CL does: reconstruct, hash, verify against the
+	// dealer's prev-round dkgPubKey.
+	kyberJ, err := types.ConvertToJustification(justs[0])
+	require.NoError(t, err)
+	require.NoError(t, schnorr.Verify(suite, c.pubs[dealerIdx], kyberJ.Justification.Hash(suite), sig))
+}
+
+// TestApplyResponses_KeyLoadFailureDropsJustification asserts that when the dealer
+// key is absent (LoadSealedEd25519Key errors), applyResponses DROPS the
+// justification rather than forwarding an unsigned one the CL would reject — while
+// still persisting the underlying response so kyber's state stays consistent.
+func TestApplyResponses_KeyLoadFailureDropsJustification(t *testing.T) {
+	t.Parallel()
+
+	suite, _, dealer, resp, dealerIdx, dealerCount, complainerCount := buildUnsignedResharingJustification(t)
+
+	const (
+		cc          = "cc-apply-responses-drop"
+		round       = uint32(5)
+		dealerRound = uint32(4)
+	)
+
+	// Do NOT seal the dealer key under dealerRound, so the lazy load fails.
+	st := newPlaintextDKGStore(t, suite)
+
+	s := &DKGServer{Suite: suite, DKGStore: st}
+
+	justs, processed, rejected, err := s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, true, cc, round, dealerRound,
+		dealerCount, complainerCount, []*pb.Response{resp},
+	)
+	require.NoError(t, err)
+
+	require.Empty(t, justs, "an unsignable justification must be dropped, not forwarded")
+	require.Empty(t, rejected, "a key-load failure is not a response rejection")
+	require.Equal(t, 1, processed, "the response must still be persisted for state consistency")
+
+	loaded, err := st.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Len(t, loaded.Responses, 1)
+	require.Equal(t, uint32(dealerIdx), loaded.Responses[0].Index)
+}
+
+// buildSignedInitialJustification runs an initial (non-resharing) DKG far enough
+// to drive one dealer to emit a kyber-SIGNED justification for a crafted complaint,
+// and returns the pieces needed to drive applyResponses through the idempotent
+// re-emit path. Unlike the resharing-own-deal path (which re-generates on every
+// call), the initial path stores the response in the verifier's aggregator, so a
+// second ProcessResponse of the same response returns the idempotent
+// "already existing response from same origin" error — exactly the retry scenario.
+func buildSignedInitialJustification(t *testing.T) (
+	suite *edwards25519.SuiteEd25519,
+	pubs []kyber.Point,
+	dealer *dkg.DistKeyGenerator,
+	resp *pb.Response,
+	dealerIdx, n int,
+) {
+	t.Helper()
+
+	suite = edwards25519.NewBlakeSHA256Ed25519()
+
+	const threshold = 2
+	n = 3
+
+	long := make([]kyber.Scalar, n)
+	pubs = make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		long[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(long[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, long[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	dealerIdx = 0
+	const verifierIdx = 1
+
+	deals, err := gens[dealerIdx].Deals()
+	require.NoError(t, err)
+
+	// Verifier processes the dealer's honest deal -> approval with the correct
+	// sessionID; flip to a complaint and re-sign so the dealer's initial path
+	// produces a kyber-SIGNED justification.
+	vresp, err := gens[verifierIdx].ProcessDeal(deals[verifierIdx])
+	require.NoError(t, err)
+
+	vresp.Response.Status = vss.StatusComplaint
+	vresp.Response.Signature, err = schnorr.Sign(suite, long[verifierIdx], vresp.Response.Hash(suite))
+	require.NoError(t, err)
+
+	resp = types.ConvertToRespProto(vresp)
+
+	return suite, pubs, gens[dealerIdx], resp, dealerIdx, n
+}
+
+// TestApplyResponses_ReEmitsEmittedJustificationOnRetry proves the fix: when a
+// ProcessResponses batch is retried (client timed out), kyber's ProcessResponse
+// is idempotent (returns j == nil) so the justification generated on the first
+// call would be lost network-wide. The re-emit path must recover the persisted
+// (signed) copy so the complaint can still be resolved. The re-emitted signature
+// must be byte-identical to the original and still verify.
+func TestApplyResponses_ReEmitsEmittedJustificationOnRetry(t *testing.T) {
+	t.Parallel()
+
+	suite, pubs, dealer, resp, dealerIdx, n := buildSignedInitialJustification(t)
+
+	const (
+		cc    = "cc-apply-responses-reemit"
+		round = uint32(5)
+	)
+
+	st := newPlaintextDKGStore(t, suite)
+	s := &DKGServer{Suite: suite, DKGStore: st}
+
+	// First call: kyber generates and signs the justification (initial path), and
+	// applyResponses persists it atomically.
+	justs1, processed1, rejected1, err := s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, false, cc, round, 0, n, n, []*pb.Response{resp},
+	)
+	require.NoError(t, err)
+	require.Empty(t, rejected1)
+	require.Equal(t, 1, processed1)
+	require.Len(t, justs1, 1)
+
+	sig1 := justs1[0].GetVssJustification().GetSignature()
+	require.NotEmpty(t, sig1)
+
+	loaded1, err := st.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Len(t, loaded1.EmittedJustifications, 1, "the generated justification must be persisted")
+
+	// Second call: same response batch + same generator. kyber is now idempotent
+	// (already existing response from same origin), so the justification can only
+	// come from the re-emit path.
+	justs2, _, rejected2, err := s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, false, cc, round, 0, n, n, []*pb.Response{resp},
+	)
+	require.NoError(t, err)
+	require.Empty(t, rejected2, "an idempotent response must not be rejected")
+	require.Len(t, justs2, 1, "the justification must be re-emitted on retry")
+
+	loaded2, err := st.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Len(t, loaded2.EmittedJustifications, 1, "no fresh justification is persisted on the idempotent retry")
+
+	sig2 := justs2[0].GetVssJustification().GetSignature()
+	require.Equal(t, sig1, sig2, "re-emitted signature must be byte-identical to the original")
+
+	// The re-emitted signature must still verify against the dealer's dkgPubKey.
+	kyberJ, err := types.ConvertToJustification(justs2[0])
+	require.NoError(t, err)
+	require.NoError(t, schnorr.Verify(suite, pubs[dealerIdx], kyberJ.Justification.Hash(suite), sig2))
+}
+
+// TestApplyResponses_SeparatesEmittedJustifications guards the replay invariant:
+// a generated justification must land ONLY in EmittedJustifications, never in
+// Justifications (peers'). replayMessages reads Justifications and re-applies them
+// into the generator, so leaking an emitted justification there would double-apply.
+func TestApplyResponses_SeparatesEmittedJustifications(t *testing.T) {
+	t.Parallel()
+
+	suite, c, dealer, resp, dealerIdx, dealerCount, complainerCount := buildUnsignedResharingJustification(t)
+
+	const (
+		cc          = "cc-apply-responses-separate"
+		round       = uint32(5)
+		dealerRound = uint32(4)
+	)
+
+	st := newPlaintextDKGStore(t, suite)
+
+	dealerBz, err := c.longterms[dealerIdx].MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, dealerRound, dealerBz))
+
+	s := &DKGServer{Suite: suite, DKGStore: st}
+
+	_, processed, _, err := s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, true, cc, round, dealerRound,
+		dealerCount, complainerCount, []*pb.Response{resp},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+
+	loaded, err := st.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Empty(t, loaded.Justifications, "peers' Justifications must stay empty; replay must never pick up own justifications")
+	require.Len(t, loaded.EmittedJustifications, 1, "the generated justification must land in EmittedJustifications")
+	require.Len(t, loaded.Responses, 1, "the processed response must be persisted")
+
+	// Sanity: the persisted own justification matches the response's (dealer,
+	// complainer) key used by the re-emit lookup.
+	require.Equal(t, uint32(dealerIdx), loaded.EmittedJustifications[0].Index)
 }

--- a/service/dkg_process_responses_test.go
+++ b/service/dkg_process_responses_test.go
@@ -530,40 +530,71 @@ func TestApplyResponses_ResharingJustificationSignedViaWiring(t *testing.T) {
 	require.NoError(t, schnorr.Verify(suite, c.pubs[dealerIdx], kyberJ.Justification.Hash(suite), sig))
 }
 
-// TestApplyResponses_KeyLoadFailureDropsJustification asserts that when the dealer
-// key is absent (LoadSealedEd25519Key errors), applyResponses DROPS the
-// justification rather than forwarding an unsigned one the CL would reject — while
-// still persisting the underlying response so kyber's state stays consistent.
-func TestApplyResponses_KeyLoadFailureDropsJustification(t *testing.T) {
+// TestApplyResponses_KeyLoadFailureSurfacesRetryableError asserts that when the
+// dealer key is absent (LoadSealedEd25519Key errors) applyResponses surfaces a
+// retryable ERROR instead of silently dropping the justification, and persists
+// NOTHING for the batch — so the CL retries the whole ProcessResponses call on a
+// later block rather than letting the dealer be invalidated. A subsequent retry
+// with the key sealed (kyber's resharing-own-deal path re-generates on every
+// call) then signs and forwards the justification, proving the self-heal.
+func TestApplyResponses_KeyLoadFailureSurfacesRetryableError(t *testing.T) {
 	t.Parallel()
 
-	suite, _, dealer, resp, dealerIdx, dealerCount, complainerCount := buildUnsignedResharingJustification(t)
+	suite, c, dealer, resp, dealerIdx, dealerCount, complainerCount := buildUnsignedResharingJustification(t)
 
 	const (
-		cc          = "cc-apply-responses-drop"
+		cc          = "cc-apply-responses-retry"
 		round       = uint32(5)
 		dealerRound = uint32(4)
 	)
 
-	// Do NOT seal the dealer key under dealerRound, so the lazy load fails.
+	// First attempt: the dealer key is NOT sealed under dealerRound, so the lazy
+	// load fails. The failure must surface as an error and persist nothing.
 	st := newPlaintextDKGStore(t, suite)
-
 	s := &DKGServer{Suite: suite, DKGStore: st}
 
 	justs, processed, rejected, err := s.applyResponses(
 		[]*dkg.DistKeyGenerator{dealer}, true, cc, round, dealerRound,
 		dealerCount, complainerCount, []*pb.Response{resp},
 	)
-	require.NoError(t, err)
+	require.Error(t, err, "a transient key-load failure must surface as an error for the CL to retry")
+	require.Empty(t, justs)
+	require.Empty(t, rejected)
+	require.Zero(t, processed)
 
-	require.Empty(t, justs, "an unsignable justification must be dropped, not forwarded")
-	require.Empty(t, rejected, "a key-load failure is not a response rejection")
-	require.Equal(t, 1, processed, "the response must still be persisted for state consistency")
+	// Nothing must be persisted for the batch, so the retry starts clean.
+	has, err := st.HasDKGState(cc, round)
+	require.NoError(t, err)
+	require.False(t, has, "no state may be persisted on the failed attempt")
+
+	// Retry with the key now available (as it would be on a later block). Reuse the
+	// same in-memory generator to mirror the cached-generator reuse in production;
+	// the resharing-own-deal path re-generates the justification, so the retry
+	// succeeds despite the earlier mutation.
+	dealerBz, err := c.longterms[dealerIdx].MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, dealerRound, dealerBz))
+
+	justs, processed, rejected, err = s.applyResponses(
+		[]*dkg.DistKeyGenerator{dealer}, true, cc, round, dealerRound,
+		dealerCount, complainerCount, []*pb.Response{resp},
+	)
+	require.NoError(t, err, "the retry must succeed once the key is available")
+	require.Empty(t, rejected)
+	require.Equal(t, 1, processed, "the response is persisted on the successful retry")
+	require.Len(t, justs, 1, "the signed justification must be forwarded on the retry")
+
+	sig := justs[0].GetVssJustification().GetSignature()
+	require.NotEmpty(t, sig, "the retry must sign the resharing justification")
+	kyberJ, err := types.ConvertToJustification(justs[0])
+	require.NoError(t, err)
+	require.NoError(t, schnorr.Verify(suite, c.pubs[dealerIdx], kyberJ.Justification.Hash(suite), sig))
 
 	loaded, err := st.LoadDKGState(cc, round)
 	require.NoError(t, err)
 	require.Len(t, loaded.Responses, 1)
 	require.Equal(t, uint32(dealerIdx), loaded.Responses[0].Index)
+	require.Len(t, loaded.EmittedJustifications, 1, "exactly one justification is persisted (no double-persist)")
 }
 
 // buildSignedInitialJustification runs an initial (non-resharing) DKG far enough

--- a/store/dkg_state.go
+++ b/store/dkg_state.go
@@ -37,19 +37,22 @@ type DKGState struct {
 
 	// Emitted* hold artifacts this node produced and returned to the CL, kept so
 	// a retried RPC re-emits them instead of losing them. Not replayed on rebuild
-	// (separate from the received Deals/Responses/Justifications above).
-	EmittedResponses []dkg.Response
+	// (separate from the received Deals/Responses/Justifications above); replaying
+	// EmittedJustifications especially would double-apply into this node's generator.
+	EmittedResponses      []dkg.Response
+	EmittedJustifications []dkg.Justification
 }
 
 type dkgStateDisk struct {
-	PubKeysBase64      []string            `json:"pub_keys_base_64"`
-	Threshold          uint32              `json:"threshold"`
-	Deals              []dkg.Deal          `json:"deals"`
-	Responses          []dkg.Response      `json:"responses"`
-	Justifications     []justificationDisk `json:"justifications,omitempty"`
-	FromRound          uint32              `json:"from_round,omitempty"`
-	PublicCoeffsBase64 []string            `json:"public_coeffs_base_64,omitempty"`
-	EmittedResponses   []dkg.Response      `json:"emitted_responses,omitempty"`
+	PubKeysBase64         []string            `json:"pub_keys_base_64"`
+	Threshold             uint32              `json:"threshold"`
+	Deals                 []dkg.Deal          `json:"deals"`
+	Responses             []dkg.Response      `json:"responses"`
+	Justifications        []justificationDisk `json:"justifications,omitempty"`
+	FromRound             uint32              `json:"from_round,omitempty"`
+	PublicCoeffsBase64    []string            `json:"public_coeffs_base_64,omitempty"`
+	EmittedResponses      []dkg.Response      `json:"emitted_responses,omitempty"`
+	EmittedJustifications []justificationDisk `json:"emitted_justifications,omitempty"`
 }
 
 // justificationDisk is the JSON-serializable representation of dkg.Justification.
@@ -270,9 +273,13 @@ func (s *DKGStore) AddProcessedDeals(codeCommitmentHex string, round uint32, dea
 	})
 }
 
-func (s *DKGStore) AddResponses(codeCommitmentHex string, round uint32, resps []dkg.Response) error {
+// AddProcessedResponses appends processed responses and the justifications this
+// node generated (and signed) for them in a single atomic write, so a retried
+// ProcessResponses can re-emit the justifications from EmittedJustifications.
+func (s *DKGStore) AddProcessedResponses(codeCommitmentHex string, round uint32, resps []dkg.Response, emittedJusts []dkg.Justification) error {
 	return s.updateState(codeCommitmentHex, round, func(st *DKGState) {
 		st.Responses = append(st.Responses, resps...)
+		st.EmittedJustifications = append(st.EmittedJustifications, emittedJusts...)
 	})
 }
 
@@ -288,14 +295,20 @@ func (s *DKGStore) toDisk(st *DKGState) (*dkgStateDisk, error) {
 		return nil, errors.Wrap(err, "marshal justifications")
 	}
 
+	emittedJustDisk, err := justificationsToDisk(st.EmittedJustifications)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal emitted justifications")
+	}
+
 	d := &dkgStateDisk{
-		Threshold:        st.Threshold,
-		Deals:            st.Deals,
-		Responses:        st.Responses,
-		Justifications:   justDisk,
-		FromRound:        st.FromRound,
-		EmittedResponses: st.EmittedResponses,
-		PubKeysBase64:    make([]string, len(st.PubKeys)),
+		Threshold:             st.Threshold,
+		Deals:                 st.Deals,
+		Responses:             st.Responses,
+		Justifications:        justDisk,
+		FromRound:             st.FromRound,
+		EmittedResponses:      st.EmittedResponses,
+		EmittedJustifications: emittedJustDisk,
+		PubKeysBase64:         make([]string, len(st.PubKeys)),
 	}
 
 	for i, p := range st.PubKeys {
@@ -327,14 +340,20 @@ func (s *DKGStore) fromDisk(d *dkgStateDisk) (*DKGState, error) {
 		return nil, errors.Wrap(err, "unmarshal justifications")
 	}
 
+	emittedJusts, err := justificationsFromDisk(s.suite, d.EmittedJustifications)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal emitted justifications")
+	}
+
 	st := &DKGState{
-		Threshold:        d.Threshold,
-		Deals:            d.Deals,
-		Responses:        d.Responses,
-		Justifications:   justs,
-		FromRound:        d.FromRound,
-		EmittedResponses: d.EmittedResponses,
-		PubKeys:          make([]kyber.Point, len(d.PubKeysBase64)),
+		Threshold:             d.Threshold,
+		Deals:                 d.Deals,
+		Responses:             d.Responses,
+		Justifications:        justs,
+		FromRound:             d.FromRound,
+		EmittedResponses:      d.EmittedResponses,
+		EmittedJustifications: emittedJusts,
+		PubKeys:               make([]kyber.Point, len(d.PubKeysBase64)),
 	}
 
 	for i, enc := range d.PubKeysBase64 {

--- a/store/dkg_state_extended_test.go
+++ b/store/dkg_state_extended_test.go
@@ -295,11 +295,11 @@ func TestAddProcessedDeals_Appends(t *testing.T) {
 }
 
 // =============================================================================
-// AddResponses tests
+// AddProcessedResponses tests
 // =============================================================================
 
-// TestAddResponses_Basic verifies responses are appended to state.
-func TestAddResponses_Basic(t *testing.T) {
+// TestAddProcessedResponses_Basic verifies responses are appended to state.
+func TestAddProcessedResponses_Basic(t *testing.T) {
 	t.Parallel()
 	store := newTestDKGStore(t)
 	suite := edwards25519.NewBlakeSHA256Ed25519()
@@ -331,15 +331,15 @@ func TestAddResponses_Basic(t *testing.T) {
 	}
 	require.NotNil(t, resp)
 
-	require.NoError(t, store.AddResponses(cc, round, []dkg.Response{*resp}))
+	require.NoError(t, store.AddProcessedResponses(cc, round, []dkg.Response{*resp}, nil))
 
 	st, err := store.LoadDKGState(cc, round)
 	require.NoError(t, err)
 	require.Len(t, st.Responses, 1)
 }
 
-// TestAddResponses_Appends verifies that subsequent calls append to existing responses.
-func TestAddResponses_Appends(t *testing.T) {
+// TestAddProcessedResponses_Appends verifies that subsequent calls append to existing responses.
+func TestAddProcessedResponses_Appends(t *testing.T) {
 	t.Parallel()
 	store := newTestDKGStore(t)
 	suite := edwards25519.NewBlakeSHA256Ed25519()
@@ -371,8 +371,8 @@ func TestAddResponses_Appends(t *testing.T) {
 	}
 	require.NotNil(t, resp)
 
-	require.NoError(t, store.AddResponses(cc, round, []dkg.Response{*resp}))
-	require.NoError(t, store.AddResponses(cc, round, []dkg.Response{*resp}))
+	require.NoError(t, store.AddProcessedResponses(cc, round, []dkg.Response{*resp}, nil))
+	require.NoError(t, store.AddProcessedResponses(cc, round, []dkg.Response{*resp}, nil))
 
 	st, err := store.LoadDKGState(cc, round)
 	require.NoError(t, err)


### PR DESCRIPTION
> **Stacked on #87** — base is `dkg/fix-process-deals-reemit`, not `main`. Review/merge #87 first.

## Problem

In every resharing round, a dealer's justification is **unsigned**, so the CL drops it (`schnorr: signature of invalid length 0`) and complaint recovery is structurally dead. Keys rotate per round, so a resharing dealer is never in the new committee (`newPresent=false`); kyber's `processResharingResponse` then hand-builds the justification **without** the Schnorr signature the normal dealing path applies (`vss.Dealer.ProcessResponse`). Fixed upstream in kyber `v4.0.2`; we are on `v4.0.0-pre2`.

## Fix

- Sign the inner `vss.Justification` with the dealer's prev-round longterm key over `j.Justification.Hash(suite)` — the exact bytes the CL verifies against the dealer's prev-round `dkgPubKey`. Only when unsigned, so the initial-DKG path (already kyber-signed) is untouched.
- Re-emit on retry (same class as #87, for the response→justification path): persist the signed justification with the response (`EmittedJustifications`), and on an idempotent retried complaint re-emit the stored copy so it is not lost.

## Tests

- `TestSignResharingJustification_ResharingSignsAndVerifies`
- `TestSignResharingJustification_PassesStoryClientVerification`
- `TestSignResharingJustification_InitialPathUntouched`
- `TestApplyResponses_ResharingJustificationSignedViaWiring`
- `TestApplyResponses_KeyLoadFailureDropsJustification`
- `TestApplyResponses_ReEmitsEmittedJustificationOnRetry`
- `TestApplyResponses_SeparatesEmittedJustifications`

issue: #85