### PR TITLE
fix(service): deal from the finalize-time sealed share to prevent polynomial divergence

### DIFF
--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -320,6 +320,7 @@ func (s *DKGServer) loadFromRoundShare(
 	share, err := s.DKGStore.LoadDistKeyShare(codeCommitmentHex, fromRound)
 	if err == nil {
 		s.DistKeyShareCache.Set(fromRound, share)
+		log.WithField("from_round", fromRound).Info("loaded from-round share from the sealed store")
 
 		return share, nil
 	}

--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -287,12 +287,7 @@ func (s *DKGServer) buildResharingPrevDKG(
 		return nil, err
 	}
 
-	existing, err := s.getOrRebuildFromRoundDKG(codeCommitmentHex, fromRound, isResharing)
-	if err != nil {
-		return nil, err
-	}
-
-	share, err := existing.DistKeyShare()
+	share, err := s.loadFromRoundShare(codeCommitmentHex, fromRound, isResharing)
 	if err != nil {
 		return nil, err
 	}
@@ -306,6 +301,43 @@ func (s *DKGServer) buildResharingPrevDKG(
 		Threshold:    int(nextT),
 		OldThreshold: int(prevT),
 	})
+}
+
+// loadFromRoundShare returns this node's fromRound DistKeyShare, preferring the
+// share sealed at finalization (cache -> sealed store -> live recompute fallback).
+// Dealing from the sealed share keeps the dealt share on the same polynomial as the
+// on-chain coeffs; a live recompute can land on a different one (kyber interpolates
+// the QUAL at call time), which makes every verifier complain.
+func (s *DKGServer) loadFromRoundShare(
+	codeCommitmentHex string,
+	fromRound uint32,
+	isResharing bool,
+) (*dkg.DistKeyShare, error) {
+	if share, ok := s.DistKeyShareCache.Get(fromRound); ok {
+		return share, nil
+	}
+
+	share, err := s.DKGStore.LoadDistKeyShare(codeCommitmentHex, fromRound)
+	if err == nil {
+		s.DistKeyShareCache.Set(fromRound, share)
+
+		return share, nil
+	}
+
+	// Fallback for a wiped disk or a pre-fix round: recompute from the live fromRound
+	// instance. Only this path still needs the fromRound DKG instance, and the recomputed
+	// share may diverge from the on-chain coeffs if the QUAL changed since finalization.
+	log.WithFields(log.Fields{
+		"from_round": fromRound,
+		"error":      err,
+	}).Warn("sealed finalize-time share missing; recomputing live share (polynomial divergence risk)")
+
+	existing, err := s.getOrRebuildFromRoundDKG(codeCommitmentHex, fromRound, isResharing)
+	if err != nil {
+		return nil, err
+	}
+
+	return existing.DistKeyShare()
 }
 
 // getOrRebuildFromRoundDKG returns the DKG instance that produced the fromRound
@@ -386,12 +418,7 @@ func (s *DKGServer) rebuildResharingPrevDKG(
 		return nil, err
 	}
 
-	existing, err := s.getOrRebuildFromRoundDKG(codeCommitmentHex, fromRound, isResharing)
-	if err != nil {
-		return nil, err
-	}
-
-	share, err := existing.DistKeyShare()
+	share, err := s.loadFromRoundShare(codeCommitmentHex, fromRound, isResharing)
 	if err != nil {
 		return nil, err
 	}

--- a/service/dist_key_gen_test.go
+++ b/service/dist_key_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"go.dedis.ch/kyber/v4"
 	"go.dedis.ch/kyber/v4/group/edwards25519"
+	"go.dedis.ch/kyber/v4/share"
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
 
 	"github.com/piplabs/story-kernel/store"
@@ -195,6 +196,7 @@ func TestGetResharingPrevDKG_FirstReshareAfterInitialDKG_RebuildPath(t *testing.
 				InitDKGCache:       store.NewDKGCache(),
 				ResharingPrevCache: store.NewResharingDKGCache(),
 				ResharingNextCache: store.NewDKGCache(),
+				DistKeyShareCache:  store.NewDistKeyShareCache(),
 			}
 			if tc.warmCache {
 				// The initial round lives in InitDKGCache (never in
@@ -270,9 +272,12 @@ func TestGetResharingPrevDKG_FirstReshareAfterInitialDKG_BuildPath(t *testing.T)
 		InitDKGCache:       store.NewDKGCache(),
 		ResharingPrevCache: store.NewResharingDKGCache(),
 		ResharingNextCache: store.NewDKGCache(),
+		DistKeyShareCache:  store.NewDistKeyShareCache(),
 	}
 	s.InitDKGCache.Set(fromRound, c.gens[self])
 
+	// No sealed fromRound share exists here, so loadFromRoundShare must fall back to
+	// recomputing the share from the live fromRound instance and still build a dealer.
 	dkgInst, err := s.GetResharingPrevDKG(cc, toRound, threshold, nextPubs, latest)
 	require.NoError(t, err)
 	require.NotNil(t, dkgInst)
@@ -285,6 +290,88 @@ func TestGetResharingPrevDKG_FirstReshareAfterInitialDKG_BuildPath(t *testing.T)
 	hasNext, err := st.HasDKGState(cc, toRound)
 	require.NoError(t, err)
 	require.True(t, hasNext, "build path must persist the toRound state")
+}
+
+// TestGetResharingPrevDKG_PrefersSealedFinalizeShare is the regression test for
+// issue #86: the resharing dealer must deal from the share sealed at fromRound's
+// finalization, not a share recomputed live. kyber's DistKeyShare() interpolates
+// the first oldT QUAL members at call time, so a live recomputation on a QUAL that
+// filled up after finalization yields a share on a different polynomial than the
+// on-chain coeffs, and every verifier complains. We seal a KNOWN share whose secret
+// differs from the live one and assert the dealer's polynomial secret (coeff[0])
+// equals the sealed value, proving the sealed share wins.
+func TestGetResharingPrevDKG_PrefersSealedFinalizeShare(t *testing.T) {
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const (
+		cc        = "cc-sealed-share"
+		fromRound = uint32(3)
+		toRound   = uint32(4)
+		threshold = 2
+	)
+
+	c := runCertifiedInitialDKG(t, 3, threshold)
+	self := 0
+
+	st := newInitialReshareStore(t, c, self, cc, fromRound, threshold)
+
+	liveShare, err := c.gens[self].DistKeyShare()
+	require.NoError(t, err)
+	coeffsBz, err := MarshalPoints(liveShare.Commitments())
+	require.NoError(t, err)
+
+	// Seal a share for fromRound whose secret differs from the live one. Reusing the
+	// live Commits keeps the blob well-formed; only Share.V drives the dealer secret.
+	knownV := suite.Scalar().SetInt64(987654321)
+	require.False(t, knownV.Equal(liveShare.PriShare().V), "sanity: known secret must differ from live")
+	sealed := &dkg.DistKeyShare{
+		Commits: liveShare.Commitments(),
+		Share:   &share.PriShare{I: liveShare.PriShare().I, V: knownV},
+	}
+	require.NoError(t, st.SealAndStoreDistKeyShare(sealed, cc, fromRound))
+
+	regs := make([]*pb.DKGRegistration, len(c.pubs))
+	for i, p := range c.pubs {
+		bz, err := p.MarshalBinary()
+		require.NoError(t, err)
+		regs[i] = &pb.DKGRegistration{Index: uint32(i + 1), Round: fromRound, DkgPubKey: bz}
+	}
+
+	point := func(seed int64) kyber.Point {
+		return suite.Point().Mul(suite.Scalar().SetInt64(seed), nil)
+	}
+	nextPubs := []kyber.Point{point(61), point(62), point(63)}
+
+	latest := &pb.DKGNetwork{Round: fromRound, Threshold: threshold, IsResharing: false, PublicCoeffs: coeffsBz}
+
+	s := &DKGServer{
+		QueryClient:        &upgradeStubQC{latest: latest, regs: regs},
+		Suite:              suite,
+		DKGStore:           st,
+		InitDKGCache:       store.NewDKGCache(),
+		ResharingPrevCache: store.NewResharingDKGCache(),
+		ResharingNextCache: store.NewDKGCache(),
+		DistKeyShareCache:  store.NewDistKeyShareCache(),
+	}
+	s.InitDKGCache.Set(fromRound, c.gens[self])
+
+	dkgInst, err := s.GetResharingPrevDKG(cc, toRound, threshold, nextPubs, latest)
+	require.NoError(t, err)
+	require.NotNil(t, dkgInst)
+
+	// The dealer polynomial's free coefficient is the secret it deals; kyber sets it
+	// to Config.Share.Share.V. It must equal the SEALED secret, not the live one.
+	polyCoeffs, err := extractDealerPolyCoeffs(dkgInst, suite)
+	require.NoError(t, err)
+	require.NotEmpty(t, polyCoeffs)
+
+	knownVBz, err := knownV.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, knownVBz, polyCoeffs[0], "dealer must deal from the sealed finalize-time secret")
+
+	liveVBz, err := liveShare.PriShare().V.MarshalBinary()
+	require.NoError(t, err)
+	require.NotEqual(t, liveVBz, polyCoeffs[0], "dealer must NOT deal from a live-recomputed secret")
 }
 
 // TestGetOrRebuildFromRoundDKG_ResharingRouting pins the isResharing=true

--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -77,6 +77,30 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 		}
 	}
 
+	// Calculate participants root from the post-invalidation participant set. The chain
+	// flips the round to the finalization stage, invalidates dealers that submitted no deal,
+	// and emits BeginDKGFinalization in the same block, so we must wait until the light
+	// client has observed that block before reading registrations. Otherwise a lagging
+	// trusted height may still report an invalidated dealer as VERIFIED, producing a
+	// participants root that disagrees with the set the chain agreed on.
+	//
+	// Snapshotting the share only after this wait also lets more of the response feed drain,
+	// so DistKeyShare() interpolates over a fuller QUAL; that same share is sealed and later
+	// used for dealing (loadFromRoundShare), keeping deals and on-chain coeffs consistent.
+	registrations, err := s.waitForFinalizationRegistrations(codeCommitmentHex, req.GetRound())
+	if err != nil {
+		log.Errorf("failed to get finalization DKG registrations: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to get finalization DKG registrations")
+	}
+
+	participantsRoot, err := calculateParticipantsRoot(registrations)
+	if err != nil {
+		log.Errorf("failed to calculate participants root: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to calculate participants root")
+	}
+
 	// Enable the timeout so DealCertified tolerates up to n-t absent verifier responses,
 	// restoring the configured threshold's fault tolerance; without it a single absent
 	// verifier fails the whole round. SetTimeout propagates to every verifier's aggregator.
@@ -133,26 +157,6 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 		log.Errorf("failed to marshal public coeffs: %v", err)
 
 		return nil, status.Errorf(codes.Internal, "failed to marshal public coeffs")
-	}
-
-	// Calculate participants root from the post-invalidation participant set. The chain
-	// flips the round to the finalization stage, invalidates dealers that submitted no deal,
-	// and emits BeginDKGFinalization in the same block, so we must wait until the light
-	// client has observed that block before reading registrations. Otherwise a lagging
-	// trusted height may still report an invalidated dealer as VERIFIED, producing a
-	// participants root that disagrees with the set the chain agreed on.
-	registrations, err := s.waitForFinalizationRegistrations(codeCommitmentHex, req.GetRound())
-	if err != nil {
-		log.Errorf("failed to get finalization DKG registrations: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to get finalization DKG registrations")
-	}
-
-	participantsRoot, err := calculateParticipantsRoot(registrations)
-	if err != nil {
-		log.Errorf("failed to calculate participants root: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to calculate participants root")
 	}
 
 	// Hash response message


### PR DESCRIPTION
## Problem

kyber's resharing `DistKeyShare()` interpolates the first `oldThreshold` members of the QUAL **at call time** — any subset recovers the same secret (GPK) but a **different polynomial**. The share was computed at two different instants: at finalize (QUAL still draining) the coeffs went on-chain and were sealed; at the next round's deal generation `buildResharingPrevDKG` **recomputed** `DistKeyShare()` on the live instance whose QUAL had since filled up, landing on a different polynomial. Every verifier then correctly complained → the round froze permanently.

## Fix

- Deal from the share **sealed at finalization** rather than recomputing. `loadFromRoundShare` resolves cache → sealed store → (fallback only) live recomputation with a Warn, and is used by both `buildResharingPrevDKG` and `rebuildResharingPrevDKG`. On-chain coeffs, the sealed share, dealing, and partial decryption now all originate from the one finalize-time computation.
- Snapshot the finalize share **after** `waitForFinalizationRegistrations`, so `DistKeyShare()` interpolates over a fuller QUAL.

## Tests

- `TestGetResharingPrevDKG_PrefersSealedFinalizeShare`

issue: #86