### PR TITLE
fix(dkg): make dealer polynomial persistence recoverable across restarts

### DIFF
--- a/dkgutil/poly_persist.go
+++ b/dkgutil/poly_persist.go
@@ -50,27 +50,44 @@ func ExtractDealerPolyCoeffs(dkgInst *dkg.DistKeyGenerator, suite *edwards25519.
 		return nil, errors.New("dealer has nil private polynomial")
 	}
 
+	// Coefficients() returns the generator's live shared polynomial, not a copy, so
+	// extraction stays read-only: zeroing it would corrupt the cached instance and make
+	// retries re-extract zeros.
 	coeffs := poly.Coefficients()
-	defer func() {
-		// Zero secret scalar coefficients to prevent heap residue
-		for _, c := range coeffs {
-			c.Zero()
-		}
-	}()
 	if len(coeffs) == 0 {
 		return nil, errors.New("dealer polynomial has no coefficients")
 	}
 
 	result := make([][]byte, len(coeffs))
+	allZero := true
 	for i, c := range coeffs {
 		bz, err := c.MarshalBinary()
 		if err != nil {
 			return nil, errors.Wrapf(err, "marshal coefficient[%d]", i)
 		}
+		if !isAllZeroBytes(bz) {
+			allZero = false
+		}
 		result[i] = bz
 	}
 
+	// A real dealer polynomial's random coefficients are never all zero; an
+	// all-zero set means corruption. Reject it before it can be sealed.
+	if allZero {
+		return nil, errors.New("dealer polynomial coefficients are all zero")
+	}
+
 	return result, nil
+}
+
+// isAllZeroBytes reports whether every byte in b is zero.
+func isAllZeroBytes(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // RestoreDealerPoly replaces the dealer's internal polynomial state in a
@@ -108,16 +125,9 @@ func RestoreDealerPoly(suite *edwards25519.SuiteEd25519, dkgInst *dkg.DistKeyGen
 		return errors.New("dkg instance has no dealer")
 	}
 
-	// Unmarshal scalar coefficients
+	// These become the restored dealer's live polynomial (CoefficientsToPriPoly stores the
+	// slice by reference), so they must not be zeroed — that would corrupt the restored poly.
 	coeffs := make([]kyber.Scalar, len(coeffBytes))
-	defer func() {
-		// Zero secret scalar coefficients to prevent heap residue
-		for _, c := range coeffs {
-			if c != nil {
-				c.Zero()
-			}
-		}
-	}()
 	for i, bz := range coeffBytes {
 		s := suite.Scalar()
 		if err := s.UnmarshalBinary(bz); err != nil {

--- a/dkgutil/poly_persist_test.go
+++ b/dkgutil/poly_persist_test.go
@@ -407,11 +407,11 @@ func TestGetDealerPublicInfo(t *testing.T) {
 	assert.Equal(t, threshold, tVal)
 }
 
-// TestExtractDealerPolyCoeffs_ZerosCoefficientsAfterUse verifies that
-// ExtractDealerPolyCoeffs zeros the in-memory scalar coefficients after
-// marshaling them. This is a defense-in-depth measure to prevent secret
-// polynomial leakage via heap residue.
-func TestExtractDealerPolyCoeffs_ZerosCoefficientsAfterUse(t *testing.T) {
+// TestExtractDealerPolyCoeffs_PreservesCoefficientsForRetry verifies that
+// ExtractDealerPolyCoeffs is non-destructive: it leaves the cached instance's
+// live polynomial intact and a second extraction returns byte-identical
+// non-zero coefficients, so a seal-failure retry re-seals the same polynomial.
+func TestExtractDealerPolyCoeffs_PreservesCoefficientsForRetry(t *testing.T) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 	dkgs, _, _ := setupTestDKG(t, 3, 2)
 
@@ -421,47 +421,98 @@ func TestExtractDealerPolyCoeffs_ZerosCoefficientsAfterUse(t *testing.T) {
 	poly := dealer.PrivatePoly()
 	require.NotNil(t, poly)
 
-	// Grab the coefficient slice — these are the same kyber.Scalar objects
-	// that ExtractDealerPolyCoeffs will zero via defer.
-	coeffsBefore := poly.Coefficients()
-	require.NotEmpty(t, coeffsBefore)
-
-	// Verify coefficients are non-zero before extraction
 	zeroScalar := suite.Scalar().Zero()
-	for i, c := range coeffsBefore {
-		require.False(t, c.Equal(zeroScalar),
-			"coefficient[%d] should be non-zero before extraction", i)
-	}
 
-	// Extract — this should marshal first, then zero the coefficients via defer
+	// First extraction succeeds with non-zero coefficients
 	coeffBytes, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
 	require.NoError(t, err)
 	require.NotEmpty(t, coeffBytes)
-
-	// Verify: the returned byte slices are valid (non-zero, can be unmarshaled)
 	for i, bz := range coeffBytes {
 		s := suite.Scalar()
-		err := s.UnmarshalBinary(bz)
-		require.NoError(t, err, "returned coefficient[%d] bytes should be valid", i)
+		require.NoError(t, s.UnmarshalBinary(bz),
+			"returned coefficient[%d] bytes should be valid", i)
 		require.False(t, s.Equal(zeroScalar),
 			"returned coefficient[%d] should represent a non-zero scalar", i)
 	}
 
-	// Verify: the original in-memory scalars have been zeroed.
-	// Since Coefficients() returns a copy of the slice but the kyber.Scalar
-	// values are pointers to the same underlying data, Zero() on those
-	// scalars mutates the actual objects. Re-fetch to confirm.
-	coeffsAfter := poly.Coefficients()
-	for i, c := range coeffsAfter {
-		assert.True(t, c.Equal(zeroScalar),
-			"coefficient[%d] should be zeroed after ExtractDealerPolyCoeffs", i)
+	// The live coefficients must remain non-zero (not corrupted by extraction)
+	for i, c := range poly.Coefficients() {
+		assert.False(t, c.Equal(zeroScalar),
+			"coefficient[%d] should be preserved (non-zero) after extraction", i)
+	}
+
+	// A second extraction on the same instance (the retry path) returns
+	// byte-identical non-zero coefficients — it never seals zeros.
+	coeffBytes2, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
+	require.NoError(t, err)
+	require.Len(t, coeffBytes2, len(coeffBytes))
+	for i := range coeffBytes {
+		assert.True(t, bytes.Equal(coeffBytes[i], coeffBytes2[i]),
+			"coefficient[%d] should be identical on retry extraction", i)
 	}
 }
 
-// TestExtractAndRestore_RoundTrip_WithZeroing verifies that the full
-// Extract -> Restore round-trip works correctly even after the zeroing
-// fix. The returned byte slices must remain valid for restoration.
-func TestExtractAndRestore_RoundTrip_WithZeroing(t *testing.T) {
+// TestExtractDealerPolyCoeffs_RejectsAllZero verifies the defense-in-depth
+// guard: an all-zero coefficient set is rejected as corruption.
+func TestExtractDealerPolyCoeffs_RejectsAllZero(t *testing.T) {
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	dkgs, _, _ := setupTestDKG(t, 3, 2)
+
+	// Zero the live polynomial to simulate corruption, then extract.
+	dealer, err := getDealerViaReflect(dkgs[0])
+	require.NoError(t, err)
+	for _, c := range dealer.PrivatePoly().Coefficients() {
+		c.Zero()
+	}
+
+	_, err = ExtractDealerPolyCoeffs(dkgs[0], suite)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all zero")
+}
+
+// TestRestoreDealerPoly_RetryExtractionMatches verifies that restoring from a
+// second (retry) extraction reproduces the same commitments and session ID as
+// the first, proving the retry path seals a recoverable polynomial.
+func TestRestoreDealerPoly_RetryExtractionMatches(t *testing.T) {
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	n, threshold := 3, 2
+	dkgs, privKeys, pubKeys := setupTestDKG(t, n, threshold)
+
+	first, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
+	require.NoError(t, err)
+	second, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
+	require.NoError(t, err)
+
+	restore := func(coeffs [][]byte) (*vss.Dealer, error) {
+		fresh, err := dkg.NewDistKeyGenerator(suite, privKeys[0], pubKeys, threshold)
+		if err != nil {
+			return nil, err
+		}
+		if err := RestoreDealerPoly(suite, fresh, coeffs); err != nil {
+			return nil, err
+		}
+		return getDealerViaReflect(fresh)
+	}
+
+	d1, err := restore(first)
+	require.NoError(t, err)
+	d2, err := restore(second)
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal(d1.SessionID(), d2.SessionID()),
+		"session ID from retry extraction should match first")
+	c1, c2 := d1.Commits(), d2.Commits()
+	require.Len(t, c2, len(c1))
+	for i := range c1 {
+		assert.True(t, c1[i].Equal(c2[i]),
+			"commitment[%d] from retry extraction should match first", i)
+	}
+}
+
+// TestExtractAndRestore_RoundTrip verifies that the full Extract -> Restore
+// round-trip works: the returned byte slices restore into a fresh instance
+// with the same session ID and commitments as the original.
+func TestExtractAndRestore_RoundTrip(t *testing.T) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 	n := 3
 	threshold := 2
@@ -474,7 +525,7 @@ func TestExtractAndRestore_RoundTrip_WithZeroing(t *testing.T) {
 	origSessionID := origDealer.SessionID()
 	origCommits := origDealer.Commits()
 
-	// Extract coefficients (this will zero the originals)
+	// Extract coefficients
 	coeffBytes, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
 	require.NoError(t, err)
 
@@ -502,13 +553,11 @@ func TestExtractAndRestore_RoundTrip_WithZeroing(t *testing.T) {
 
 // TestExtractAndRestoreCoefficients_CoefficientsPreserved verifies that
 // extracted coefficient bytes faithfully represent the original polynomial.
-// Note: after extraction, the in-memory scalars are zeroed (defense-in-depth),
-// so we capture the original bytes BEFORE calling ExtractDealerPolyCoeffs.
 func TestExtractAndRestoreCoefficients_CoefficientsPreserved(t *testing.T) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 	dkgs, _, _ := setupTestDKG(t, 3, 2)
 
-	// Capture original coefficient bytes BEFORE extraction (which zeros them)
+	// Capture original coefficient bytes for comparison against extraction
 	origDealer, err := getDealerViaReflect(dkgs[0])
 	require.NoError(t, err)
 	origCoeffs := origDealer.PrivatePoly().Coefficients()
@@ -520,7 +569,7 @@ func TestExtractAndRestoreCoefficients_CoefficientsPreserved(t *testing.T) {
 		origCoeffBytes[i] = bz
 	}
 
-	// Extract coefficients (this will zero the in-memory scalars)
+	// Extract coefficients
 	coeffBytes, err := ExtractDealerPolyCoeffs(dkgs[0], suite)
 	require.NoError(t, err)
 

--- a/service/dkg_generate_deals.go
+++ b/service/dkg_generate_deals.go
@@ -92,25 +92,24 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 		return nil, status.Errorf(codes.Internal, "failed to generate encrypted deals")
 	}
 
-	// Persist dealer polynomial coefficients for restart recovery.
-	// If GenerateDeals succeeds but the kernel restarts before FinalizeDKG,
-	// the rebuild functions (rebuildInitDKG, rebuildResharingPrevDKG) need the
-	// original polynomial to restore the dealer state (session ID, commitments)
-	// correctly. Without this, a new random polynomial would be generated,
-	// causing session ID mismatches with peers who already received the original
-	// deals.
-	//
-	// This covers both initial and resharing rounds. In resharing, only the
-	// secret coefficient (Share.V) is deterministic — the remaining t-1
-	// polynomial coefficients are still random, producing different commitments
-	// and session ID on each NewDistKeyHandler call.
-	coeffs, extractErr := extractDealerPolyCoeffs(distKeyGen, s.Suite)
-	if extractErr == nil && len(coeffs) > 0 {
-		if persistErr := s.DKGStore.SetPrivateCoeffs(codeCommitmentHex, req.GetRound(), coeffs); persistErr != nil {
-			log.Warnf("failed to persist dealer polynomial coefficients: %v", persistErr)
+	// Persist the dealer polynomial (sealed) so a restart before FinalizeDKG restores the
+	// same polynomial instead of a fresh random one, which would break the session ID and
+	// evict this node from QUAL. Seal must succeed before returning: on error the CL retries
+	// with the same cached generator, so deals are never broadcast without recoverable coeffs.
+	coeffs, err := extractDealerPolyCoeffs(distKeyGen, s.Suite)
+	if err != nil {
+		log.Errorf("failed to extract dealer polynomial coefficients: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to extract dealer polynomial coefficients")
+	}
+
+	// A non-dealer legitimately has no coefficients (len==0, no error): skip persist.
+	if len(coeffs) > 0 {
+		if err := s.DKGStore.SetPrivateCoeffs(codeCommitmentHex, req.GetRound(), coeffs); err != nil {
+			log.Errorf("failed to persist dealer polynomial coefficients: %v", err)
+
+			return nil, status.Errorf(codes.Internal, "failed to persist dealer polynomial coefficients")
 		}
-	} else if extractErr != nil {
-		log.Warnf("failed to extract dealer polynomial coefficients: %v", extractErr)
 	}
 
 	log.Info("Succeed to generate deals", "code_commitment", codeCommitmentHex, "round", req.GetRound())

--- a/store/dkg_state_test.go
+++ b/store/dkg_state_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -509,4 +510,39 @@ func TestSaveStateOverwrite(t *testing.T) {
 	st, err := store.LoadDKGState(codeCommitment, round)
 	require.NoError(t, err)
 	require.Equal(t, uint32(5), st.Threshold, "overwritten state should have new threshold")
+}
+
+// failingSealer is a test-only sealer whose SealToFile always fails, simulating
+// a sealed-storage write failure.
+type failingSealer struct{}
+
+func (failingSealer) SealToFile(_ []byte, _ string) error {
+	return errFailingSealer
+}
+
+func (failingSealer) UnsealFromFile(_ string) ([]byte, error) {
+	return nil, errFailingSealer
+}
+
+var errFailingSealer = errors.New("sealer failure")
+
+// TestSetPrivateCoeffs_SealFailureSurfacesError verifies that a sealing failure
+// surfaces as an error from SetPrivateCoeffs. GenerateDeals relies on this: it
+// must NOT return deals to the CL when the dealer polynomial cannot be durably
+// sealed, otherwise a restart would regenerate a fresh polynomial and evict the
+// node from QUAL.
+func TestSetPrivateCoeffs_SealFailureSurfacesError(t *testing.T) {
+	t.Parallel()
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	dir := t.TempDir()
+	store := NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		suite,
+		failingSealer{},
+	)
+
+	err := store.SetPrivateCoeffs("failseal", 1, [][]byte{{0x01}, {0x02}})
+	require.ErrorIs(t, err, errFailingSealer,
+		"a sealing failure must surface as an error, not be swallowed")
 }


### PR DESCRIPTION
## Problem
Two defects broke restart recovery of a dealer's polynomial (both shipped in `0.1.0`):
- `GenerateDeals` logged and swallowed `SetPrivateCoeffs` (seal) failures, then broadcast the deals anyway. If sealing failed, the node broadcast deals whose polynomial was never persisted; on the next restart it regenerated a fresh random polynomial, causing a session-ID/commitment mismatch with peers and eviction from QUAL.
- `ExtractDealerPolyCoeffs` and `RestoreDealerPoly` zeroed coefficients via `defer c.Zero()` for heap hygiene, but kyber's `PriPoly.Coefficients()` returns the generator's **live** internal slice, not a copy. This destroyed the cached `DistKeyGenerator`'s polynomial: extraction corrupted the instance so a retry re-extracted zeros, and restore wiped the polynomial it had just reconstructed. The hygiene was also ineffective — the secret still lives in the cached generator (polynomial + precomputed deals) and is deliberately sealed to disk — so it protected nothing while breaking recovery.

## Fix
- Return an error from `GenerateDeals` when sealing fails, so the CL retries with the same cached generator; deals are never broadcast without recoverable coefficients.
- Make `ExtractDealerPolyCoeffs` and `RestoreDealerPoly` read-only (remove the destructive zeroing); restart recovery now works end-to-end.
- Reject an all-zero coefficient set before sealing as a corruption guard.

## Tests
- `TestExtractDealerPolyCoeffs_PreservesCoefficientsForRetry`, `TestExtractDealerPolyCoeffs_RejectsAllZero`
- `TestRestoreDealerPoly_RetryExtractionMatches`
- `TestSetPrivateCoeffs_SealFailureSurfacesError`

issue: none
