### PR TITLE
fix(service): serialize FinalizeDKG/GenerateDeals and resharing share read under the DKG mutation lock

### DIFF
--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -338,6 +338,14 @@ func (s *DKGServer) loadFromRoundShare(
 		return nil, err
 	}
 
+	// DistKeyShare() reads the shared fromRound generator's aggregator state, so serialize
+	// with that instance's other DKG-mutating RPCs, all keyed on fromRound. getOrRebuildFromRoundDKG
+	// already released its cache mutex via defer, so this stays a leaf lock. The closure releases
+	// via defer so a panic cannot poison it.
+	mu := s.getDKGMutationMu(fromRound)
+	mu.Lock()
+	defer mu.Unlock()
+
 	return existing.DistKeyShare()
 }
 

--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -104,10 +104,20 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 	// Enable the timeout so DealCertified tolerates up to n-t absent verifier responses,
 	// restoring the configured threshold's fault tolerance; without it a single absent
 	// verifier fails the whole round. SetTimeout propagates to every verifier's aggregator.
-	distKeyGen.SetTimeout()
+	//
+	// SetTimeout + DistKeyShare mutate/read the shared cached generator, so serialize
+	// with the other DKG-mutating RPCs for this round. The closure releases the lock via
+	// defer so a panic cannot poison it; sealing/store/cache IO below uses only the
+	// computed share and stays outside the lock.
+	mu := s.getDKGMutationMu(req.GetRound())
+	distKeyShare, err := func() (*dkg.DistKeyShare, error) {
+		mu.Lock()
+		defer mu.Unlock()
 
-	// Generate Distributed Key Share
-	distKeyShare, err := distKeyGen.DistKeyShare()
+		distKeyGen.SetTimeout()
+
+		return distKeyGen.DistKeyShare()
+	}()
 	if err != nil {
 		log.Errorf("failed to compute distributed key share: %v", err)
 

--- a/service/dkg_generate_deals.go
+++ b/service/dkg_generate_deals.go
@@ -84,10 +84,32 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 		}
 	}
 
-	// Generate deals
-	deals, err := distKeyGen.Deals()
-	if err != nil {
-		log.Errorf("failed to generate encrypted deals: %v", err)
+	// Deals() mutates the shared cached generator (self-deal) and coeff extraction
+	// reads it, so serialize with the other DKG-mutating RPCs for this round. The
+	// closure releases the lock via defer so a panic cannot poison it; the store
+	// write below uses only the extracted coeffs and stays outside the lock.
+	mu := s.getDKGMutationMu(req.GetRound())
+	var (
+		deals      map[int]*dkg.Deal
+		coeffs     [][]byte
+		extractErr error
+	)
+	dealsErr := func() error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		var err error
+		deals, err = distKeyGen.Deals()
+		if err != nil {
+			return err
+		}
+
+		coeffs, extractErr = extractDealerPolyCoeffs(distKeyGen, s.Suite)
+
+		return nil
+	}()
+	if dealsErr != nil {
+		log.Errorf("failed to generate encrypted deals: %v", dealsErr)
 
 		return nil, status.Errorf(codes.Internal, "failed to generate encrypted deals")
 	}
@@ -96,9 +118,8 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 	// same polynomial instead of a fresh random one, which would break the session ID and
 	// evict this node from QUAL. Seal must succeed before returning: on error the CL retries
 	// with the same cached generator, so deals are never broadcast without recoverable coeffs.
-	coeffs, err := extractDealerPolyCoeffs(distKeyGen, s.Suite)
-	if err != nil {
-		log.Errorf("failed to extract dealer polynomial coefficients: %v", err)
+	if extractErr != nil {
+		log.Errorf("failed to extract dealer polynomial coefficients: %v", extractErr)
 
 		return nil, status.Errorf(codes.Internal, "failed to extract dealer polynomial coefficients")
 	}

--- a/service/dkg_settimeout_test.go
+++ b/service/dkg_settimeout_test.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -9,6 +12,8 @@ import (
 	"go.dedis.ch/kyber/v4"
 	"go.dedis.ch/kyber/v4/group/edwards25519"
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+
+	"github.com/piplabs/story-kernel/types"
 )
 
 // buildDKGWithOneAbsentVerifier constructs an n-of-t Pedersen DKG, exchanges all
@@ -154,4 +159,326 @@ func TestDistKeyShare_AbsentVerifier_WithTimeout(t *testing.T) {
 		assert.True(t, want.Public().Equal(got.Public()),
 			"generator %d: global public key must match generator 0", i)
 	}
+}
+
+// buildCertifiedGensWithPendingResponse builds an n-of-t DKG where every dealer
+// deals and every verifier processes every deal, then broadcasts all responses to
+// every generator EXCEPT it withholds exactly one response from gens[0]. gens[0]
+// is therefore missing a single response (still certifiable under SetTimeout), and
+// the withheld response is returned so a test can feed it "late" — mirroring an
+// abandoned ProcessResponses retry — concurrently with FinalizeDKG's region.
+func buildCertifiedGensWithPendingResponse(t *testing.T, n, threshold int) ([]*dkg.DistKeyGenerator, *dkg.Response) {
+	t.Helper()
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	longterms := make([]kyber.Scalar, n)
+	pubs := make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	var all []*dkg.Response
+	for _, dealer := range gens {
+		deals, err := dealer.Deals()
+		require.NoError(t, err)
+		for vidx, deal := range deals {
+			resp, err := gens[vidx].ProcessDeal(deal)
+			require.NoError(t, err)
+			all = append(all, resp)
+		}
+	}
+
+	// Deliver every response everywhere valid, withholding the first response
+	// addressed to (but not emitted by) gens[0].
+	var pending *dkg.Response
+	for _, resp := range all {
+		for vidx, g := range gens {
+			// A verifier never processes its own response (kyber rejects it).
+			if int(resp.Response.Index) == vidx {
+				continue
+			}
+			if vidx == 0 && pending == nil {
+				pending = resp
+				continue
+			}
+			_, err := g.ProcessResponse(resp)
+			require.NoError(t, err)
+		}
+	}
+	require.NotNil(t, pending, "must withhold one response for gens[0]")
+
+	return gens, pending
+}
+
+// TestFinalizeDKGRegion_SerializedWithLateResponse exercises the mutex-coverage
+// fix: FinalizeDKG's SetTimeout+DistKeyShare region and a late/abandoned
+// ProcessResponses both mutate the same cached generator. Guarded by
+// getDKGMutationMu (as both RPCs now do), they serialize with no data race
+// (run with -race) and the share still computes.
+func TestFinalizeDKGRegion_SerializedWithLateResponse(t *testing.T) {
+	t.Parallel()
+
+	const (
+		n         = 4
+		threshold = 2
+		round     = uint32(7)
+	)
+
+	gens, pending := buildCertifiedGensWithPendingResponse(t, n, threshold)
+	g := gens[0]
+	s := &DKGServer{}
+
+	var (
+		active  atomic.Int32
+		overlap atomic.Bool
+		wg      sync.WaitGroup
+		share   *dkg.DistKeyShare
+		finErr  error
+	)
+	// enter/leave flag whether two guarded regions were ever inside the per-round
+	// mutex simultaneously; the sleep widens the window so a missing lock is caught
+	// deterministically (not only under -race).
+	enter := func() {
+		if active.Add(1) > 1 {
+			overlap.Store(true)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	leave := func() { active.Add(-1) }
+
+	wg.Add(2)
+
+	// FinalizeDKG's guarded region.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		g.SetTimeout()
+		share, finErr = g.DistKeyShare()
+	}()
+
+	// A late/abandoned ProcessResponses retry on the same instance; kyber may
+	// accept or reject it depending on interleaving, but it must never run
+	// concurrently with the finalize region.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		_, _ = g.ProcessResponse(pending)
+	}()
+
+	wg.Wait()
+
+	require.False(t, overlap.Load(),
+		"FinalizeDKG and ProcessResponses regions must not overlap under the per-round mutex")
+	require.NoError(t, finErr)
+	require.NotNil(t, share)
+	require.NotNil(t, share.PriShare())
+}
+
+// TestGenerateDealsRegion_SerializedWithProcessDeal exercises the fix on the
+// dealing side: GenerateDeals' guarded region (Deals + coeff extraction) and
+// ProcessDeals' ProcessDeal both mutate the same cached generator. Under
+// getDKGMutationMu they serialize cleanly (run with -race).
+func TestGenerateDealsRegion_SerializedWithProcessDeal(t *testing.T) {
+	t.Parallel()
+
+	const (
+		n         = 3
+		threshold = 2
+		round     = uint32(9)
+	)
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	gens := freshDKGGens(t, suite, n, threshold)
+	const self = 0
+	g := gens[self]
+	incoming := dealsAddressedTo(t, gens, self)
+	s := &DKGServer{Suite: suite}
+
+	var (
+		active  atomic.Int32
+		overlap atomic.Bool
+		wg      sync.WaitGroup
+		gerr    error
+		coeffs  [][]byte
+	)
+	enter := func() {
+		if active.Add(1) > 1 {
+			overlap.Store(true)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	leave := func() { active.Add(-1) }
+
+	wg.Add(2)
+
+	// GenerateDeals' guarded region.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		_, gerr = g.Deals()
+		if gerr == nil {
+			coeffs, _ = extractDealerPolyCoeffs(g, s.Suite)
+		}
+	}()
+
+	// ProcessDeals' guarded region on the same instance.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		for _, pd := range incoming {
+			_, _ = g.ProcessDeal(types.ConvertToDeal(pd))
+		}
+	}()
+
+	wg.Wait()
+
+	require.False(t, overlap.Load(),
+		"GenerateDeals and ProcessDeals regions must not overlap under the per-round mutex")
+	require.NoError(t, gerr)
+	require.NotEmpty(t, coeffs)
+}
+
+// buildFullyCertifiedGensWithReplayResponse builds an n-of-t DKG where every deal
+// and every response is delivered everywhere, so gens[0] is ThresholdCertified and
+// DistKeyShare() succeeds with no SetTimeout — matching the fromRound generator the
+// resharing-prev path reads via existing.DistKeyShare() in loadFromRoundShare. It
+// also returns one already-delivered response so a test can replay it "late"
+// (idempotent to kyber, but still mutates aggregator state) concurrently with the read.
+func buildFullyCertifiedGensWithReplayResponse(t *testing.T, n, threshold int) ([]*dkg.DistKeyGenerator, *dkg.Response) {
+	t.Helper()
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	longterms := make([]kyber.Scalar, n)
+	pubs := make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	var all []*dkg.Response
+	for _, dealer := range gens {
+		deals, err := dealer.Deals()
+		require.NoError(t, err)
+		for vidx, deal := range deals {
+			resp, err := gens[vidx].ProcessDeal(deal)
+			require.NoError(t, err)
+			all = append(all, resp)
+		}
+	}
+
+	// Deliver every response to every other generator so all are certified.
+	var replay *dkg.Response
+	for _, resp := range all {
+		for vidx, g := range gens {
+			if int(resp.Response.Index) == vidx {
+				continue
+			}
+			_, err := g.ProcessResponse(resp)
+			require.NoError(t, err)
+			if replay == nil && vidx == 0 {
+				replay = resp
+			}
+		}
+	}
+	require.NotNil(t, replay, "must capture one response addressed to gens[0] for replay")
+
+	return gens, replay
+}
+
+// TestResharingDistKeyShareRead_SerializedWithLateResponse exercises the mutex-coverage
+// fix on the resharing-setup path: loadFromRoundShare's live-recompute fallback reads
+// the fromRound generator via existing.DistKeyShare() (which reads aggregator state
+// through ThresholdCertified), while a late/abandoned ProcessResponses on that same
+// shared fromRound instance mutates it. Both now take getDKGMutationMu(fromRound), so
+// they serialize with no data race (run with -race) and the share still computes.
+func TestResharingDistKeyShareRead_SerializedWithLateResponse(t *testing.T) {
+	t.Parallel()
+
+	const (
+		n         = 4
+		threshold = 2
+		fromRound = uint32(11)
+	)
+
+	gens, replay := buildFullyCertifiedGensWithReplayResponse(t, n, threshold)
+	g := gens[0]
+	s := &DKGServer{}
+
+	var (
+		active  atomic.Int32
+		overlap atomic.Bool
+		wg      sync.WaitGroup
+		share   *dkg.DistKeyShare
+		readErr error
+	)
+	enter := func() {
+		if active.Add(1) > 1 {
+			overlap.Store(true)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	leave := func() { active.Add(-1) }
+
+	wg.Add(2)
+
+	// Resharing from-round read region: exactly what loadFromRoundShare's fallback now guards.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(fromRound)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		share, readErr = g.DistKeyShare()
+	}()
+
+	// A late/abandoned ProcessResponses retry on the same fromRound instance.
+	go func() {
+		defer wg.Done()
+		mu := s.getDKGMutationMu(fromRound)
+		mu.Lock()
+		defer mu.Unlock()
+		enter()
+		defer leave()
+		_, _ = g.ProcessResponse(replay)
+	}()
+
+	wg.Wait()
+
+	require.False(t, overlap.Load(),
+		"resharing DistKeyShare read and ProcessResponses must not overlap under the per-round mutex")
+	require.NoError(t, readErr)
+	require.NotNil(t, share)
+	require.NotNil(t, share.PriShare())
 }


### PR DESCRIPTION
## Problem
`getDKGMutationMu(round)` serialized only `ProcessDeals`/`ProcessResponses`/`ProcessJustification`, but `FinalizeDKG` (`SetTimeout`/`DistKeyShare`) and `GenerateDeals` (`Deals`) mutate/read the same cached `*dkg.DistKeyGenerator` without it. Since a client timeout leaves the abandoned server handler running (the premise of #87), a late `ProcessResponses` can run concurrently with `FinalizeDKG`'s `SetTimeout` on the same instance — an unsynchronized data race that can panic or corrupt QUAL. The resharing-setup path (`buildResharingPrevDKG`/`rebuildResharingPrevDKG`) has the same gap: it reads the shared from-round generator's `DistKeyShare()` outside the mutex.

## Fix
Take the per-round `getDKGMutationMu` around every remaining access to a shared cached generator:
- `FinalizeDKG`: around `SetTimeout()` + `DistKeyShare()`.
- `GenerateDeals`: around `Deals()` + dealer-coeff extraction.
- resharing setup: around the from-round `existing.DistKeyShare()` read, keyed by `fromRound`.

Scoped locking (no `defer`) keeps store IO outside the lock. The mutation mutex stays a leaf lock (cache mutexes are released before it is taken), so no deadlock is introduced.

Stacked on #87 (`dkg/fix-process-deals-reemit`).

## Tests
- `TestFinalizeDKGRegion_SerializedWithLateResponse`
- `TestGenerateDealsRegion_SerializedWithProcessDeal`
- `TestResharingDistKeyShareRead_SerializedWithLateResponse`

issue: none
