### PR TITLE
refactor(service): centralize per-round DKG mutation locking

### DIFF
--- a/service/dist_key_gen.go
+++ b/service/dist_key_gen.go
@@ -340,13 +340,17 @@ func (s *DKGServer) loadFromRoundShare(
 
 	// DistKeyShare() reads the shared fromRound generator's aggregator state, so serialize
 	// with that instance's other DKG-mutating RPCs, all keyed on fromRound. getOrRebuildFromRoundDKG
-	// already released its cache mutex via defer, so this stays a leaf lock. The closure releases
-	// via defer so a panic cannot poison it.
-	mu := s.getDKGMutationMu(fromRound)
-	mu.Lock()
-	defer mu.Unlock()
+	// already released its cache mutex via defer, so this stays a leaf lock.
+	if lockErr := s.withRoundMutation(fromRound, func() error {
+		var derr error
+		share, derr = existing.DistKeyShare()
 
-	return existing.DistKeyShare()
+		return derr
+	}); lockErr != nil {
+		return nil, lockErr
+	}
+
+	return share, nil
 }
 
 // getOrRebuildFromRoundDKG returns the DKG instance that produced the fromRound

--- a/service/dkg_finalize.go
+++ b/service/dkg_finalize.go
@@ -106,19 +106,17 @@ func (s *DKGServer) FinalizeDKG(_ context.Context, req *pb.FinalizeDKGRequest) (
 	// verifier fails the whole round. SetTimeout propagates to every verifier's aggregator.
 	//
 	// SetTimeout + DistKeyShare mutate/read the shared cached generator, so serialize
-	// with the other DKG-mutating RPCs for this round. The closure releases the lock via
-	// defer so a panic cannot poison it; sealing/store/cache IO below uses only the
-	// computed share and stays outside the lock.
-	mu := s.getDKGMutationMu(req.GetRound())
-	distKeyShare, err := func() (*dkg.DistKeyShare, error) {
-		mu.Lock()
-		defer mu.Unlock()
-
+	// with the other DKG-mutating RPCs for this round. Sealing/store/cache IO below uses
+	// only the computed share and stays outside the lock.
+	var distKeyShare *dkg.DistKeyShare
+	if err := s.withRoundMutation(req.GetRound(), func() error {
 		distKeyGen.SetTimeout()
 
-		return distKeyGen.DistKeyShare()
-	}()
-	if err != nil {
+		var err error
+		distKeyShare, err = distKeyGen.DistKeyShare()
+
+		return err
+	}); err != nil {
 		log.Errorf("failed to compute distributed key share: %v", err)
 
 		return nil, status.Errorf(codes.Internal, "failed to compute distributed key share")

--- a/service/dkg_generate_deals.go
+++ b/service/dkg_generate_deals.go
@@ -86,18 +86,13 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 
 	// Deals() mutates the shared cached generator (self-deal) and coeff extraction
 	// reads it, so serialize with the other DKG-mutating RPCs for this round. The
-	// closure releases the lock via defer so a panic cannot poison it; the store
-	// write below uses only the extracted coeffs and stays outside the lock.
-	mu := s.getDKGMutationMu(req.GetRound())
+	// store write below uses only the extracted coeffs and stays outside the lock.
 	var (
 		deals      map[int]*dkg.Deal
 		coeffs     [][]byte
 		extractErr error
 	)
-	dealsErr := func() error {
-		mu.Lock()
-		defer mu.Unlock()
-
+	dealsErr := s.withRoundMutation(req.GetRound(), func() error {
 		var err error
 		deals, err = distKeyGen.Deals()
 		if err != nil {
@@ -107,7 +102,7 @@ func (s *DKGServer) GenerateDeals(_ context.Context, req *pb.GenerateDealsReques
 		coeffs, extractErr = extractDealerPolyCoeffs(distKeyGen, s.Suite)
 
 		return nil
-	}()
+	})
 	if dealsErr != nil {
 		log.Errorf("failed to generate encrypted deals: %v", dealsErr)
 

--- a/service/dkg_process_deals.go
+++ b/service/dkg_process_deals.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/piplabs/story-kernel/enclave"
+	"github.com/piplabs/story-kernel/store"
 	"github.com/piplabs/story-kernel/types"
 	pb "github.com/piplabs/story-kernel/types/pb/v0"
 
@@ -58,26 +59,24 @@ func isAlreadyProcessedErr(err error) bool {
 		strings.Contains(msg, errKyberJustificationOnApproval.Error())
 }
 
+// maxResolveDealsAttempts bounds the warm->lock->cache-get retry loop so a
+// persistent evict/re-warm cycle returns Unavailable instead of spinning.
+const maxResolveDealsAttempts = 3
+
+// processedDeals carries applyDeals' output out of the locked closure. A nil
+// result with a nil error signals an eviction, so the caller re-warms.
+type processedDeals struct {
+	resps     []*pb.Response
+	persisted int
+	rejected  []*pb.Deal
+}
+
 // ProcessDeals process the deals. It is assumed that the deal has been correctly delivered to the corresponding recipient index.
 func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest) (*pb.ProcessDealsResponse, error) {
 	codeCommitmentHex := hex.EncodeToString(req.GetCodeCommitment())
 
-	// Validate request
-	if err := validateProcessDealsRequest(req); err != nil {
-		log.WithFields(log.Fields{
-			"round":           req.GetRound(),
-			"code_commitment": codeCommitmentHex,
-			"num_deals":       len(req.GetDeals()),
-		}).Errorf("invalid request: %v", err)
-
-		return nil, status.Errorf(codes.InvalidArgument, "invalid request")
-	}
-
-	// Validate code commitment
-	if err := enclave.ValidateCodeCommitment(req.GetCodeCommitment()); err != nil {
-		log.Errorf("failed to validate code commitment: %v", err)
-
-		return nil, status.Errorf(codes.InvalidArgument, "failed to validate code commitment")
+	if err := validateProcessDealsInput(req, codeCommitmentHex); err != nil {
+		return nil, err
 	}
 
 	rc, err := s.GetOrLoadRoundContext(codeCommitmentHex, req.GetRound())
@@ -90,56 +89,14 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 		return nil, status.Errorf(codes.Internal, "failed to get or load roundContext")
 	}
 
-	// dealerCount upper-bounds Deal.Index. Non-resharing has a single
-	// committee acting as dealers; resharing dealers are members of the
-	// PRIOR active committee (kyber's c.OldNodes inside the next-DKG).
-	var (
-		distKeyGen  *dkg.DistKeyGenerator
-		dealerCount int
-	)
-	if !req.GetIsResharing() {
-		dealerCount = len(rc.SortedPubKeys)
-
-		distKeyGen, err = s.GetInitDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
-		if err != nil {
-			log.Errorf("failed to load or rebuild initial distributed key generator: %v", err)
-
-			return nil, status.Errorf(codes.Internal, "failed to load or rebuild initial distributed key generator")
-		}
-	} else {
-		latest, err := s.QueryClient.GetLatestActiveDKGNetwork(context.Background())
-		if err != nil {
-			log.Errorf("failed to get the latest active round of DKG: %v", err)
-
-			return nil, status.Errorf(codes.Internal, "failed to get the latest active round of DKG")
-		}
-		if latest == nil || latest.GetTotal() == 0 {
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"resharing requires an active prior DKG network")
-		}
-		dealerCount = int(latest.GetTotal())
-
-		distKeyGen, err = s.GetResharingNextDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
-		if err != nil {
-			log.Errorf("failed to load or rebuild the distributed key generator for resharing: %v", err)
-
-			return nil, status.Errorf(codes.Internal, "failed to load or rebuild the distributed key generator for resharing")
-		}
+	dealerCount, err := s.resolveDealerCount(rc, req)
+	if err != nil {
+		return nil, err
 	}
 
-	// Serialize with any concurrent DKG-mutating RPC for this round: a client
-	// timeout leaves the abandoned server handler running, and its retry (or an
-	// adjacent ProcessResponses/Justification) must not mutate the shared
-	// DistKeyGenerator at the same time. Held across process+persist so the
-	// retry sees a fully persisted state and re-emits deterministically.
-	mu := s.getDKGMutationMu(req.GetRound())
-	mu.Lock()
-	pbResps, persisted, rejected, err := s.applyDeals(distKeyGen, codeCommitmentHex, req.GetRound(), dealerCount, req.GetDeals())
-	mu.Unlock()
+	out, err := s.resolveAndApplyDeals(codeCommitmentHex, rc, req, dealerCount)
 	if err != nil {
-		log.Errorf("failed to persist processed deals: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to persist processed deals")
+		return nil, err
 	}
 
 	// responses = total emitted this call (incl. re-emitted on retry);
@@ -147,17 +104,157 @@ func (s *DKGServer) ProcessDeals(_ context.Context, req *pb.ProcessDealsRequest)
 	log.WithFields(log.Fields{
 		"code_commitment": codeCommitmentHex,
 		"round":           req.GetRound(),
-		"responses":       len(pbResps),
-		"persisted_deals": persisted,
-		"rejected":        len(rejected),
+		"responses":       len(out.resps),
+		"persisted_deals": out.persisted,
+		"rejected":        len(out.rejected),
 	}).Info("Processed deals")
 
 	return &pb.ProcessDealsResponse{
 		CodeCommitment: req.GetCodeCommitment(),
 		Round:          req.GetRound(),
-		Responses:      pbResps,
-		RejectedDeals:  rejected,
+		Responses:      out.resps,
+		RejectedDeals:  out.rejected,
 	}, nil
+}
+
+// validateProcessDealsInput runs the request and code-commitment checks,
+// returning a ready-to-return status error on failure.
+func validateProcessDealsInput(req *pb.ProcessDealsRequest, codeCommitmentHex string) error {
+	if err := validateProcessDealsRequest(req); err != nil {
+		log.WithFields(log.Fields{
+			"round":           req.GetRound(),
+			"code_commitment": codeCommitmentHex,
+			"num_deals":       len(req.GetDeals()),
+		}).Errorf("invalid request: %v", err)
+
+		return status.Errorf(codes.InvalidArgument, "invalid request")
+	}
+
+	if err := enclave.ValidateCodeCommitment(req.GetCodeCommitment()); err != nil {
+		log.Errorf("failed to validate code commitment: %v", err)
+
+		return status.Errorf(codes.InvalidArgument, "failed to validate code commitment")
+	}
+
+	return nil
+}
+
+// resolveDealerCount upper-bounds Deal.Index. Non-resharing has a single
+// committee acting as dealers; resharing dealers are members of the PRIOR
+// active committee (kyber's c.OldNodes inside the next-DKG).
+func (s *DKGServer) resolveDealerCount(rc *store.RoundContext, req *pb.ProcessDealsRequest) (int, error) {
+	if !req.GetIsResharing() {
+		return len(rc.SortedPubKeys), nil
+	}
+
+	latest, err := s.QueryClient.GetLatestActiveDKGNetwork(context.Background())
+	if err != nil {
+		log.Errorf("failed to get the latest active round of DKG: %v", err)
+
+		return 0, status.Errorf(codes.Internal, "failed to get the latest active round of DKG")
+	}
+	if latest == nil || latest.GetTotal() == 0 {
+		return 0, status.Errorf(codes.FailedPrecondition,
+			"resharing requires an active prior DKG network")
+	}
+
+	return int(latest.GetTotal()), nil
+}
+
+// resolveAndApplyDeals retries a warm+apply attempt until it yields deals or is
+// exhausted, re-warming on each eviction (the #94 warm-vs-lock race). Exhaustion
+// returns Unavailable.
+func (s *DKGServer) resolveAndApplyDeals(
+	codeCommitmentHex string,
+	rc *store.RoundContext,
+	req *pb.ProcessDealsRequest,
+	dealerCount int,
+) (*processedDeals, error) {
+	for attempt := 0; attempt < maxResolveDealsAttempts; attempt++ {
+		out, err := s.attemptDeals(codeCommitmentHex, rc, req, dealerCount)
+		if err != nil {
+			return nil, err
+		}
+		if out != nil {
+			return out, nil
+		}
+		// Evicted between warm and lock: re-warm outside M and retry.
+	}
+
+	log.Errorf("failed to resolve a live generator for round %d after %d attempts", req.GetRound(), maxResolveDealsAttempts)
+
+	return nil, status.Errorf(codes.Unavailable, "failed to resolve a live generator")
+}
+
+// attemptDeals runs one pass: warm the generator outside M, then apply the deals under M.
+// A nil result with a nil error means the round was evicted between the warm and the lock,
+// signalling the caller to retry.
+func (s *DKGServer) attemptDeals(
+	codeCommitmentHex string,
+	rc *store.RoundContext,
+	req *pb.ProcessDealsRequest,
+	dealerCount int,
+) (*processedDeals, error) {
+	if err := s.warmGenerator(codeCommitmentHex, rc, req); err != nil {
+		log.Errorf("failed to load or rebuild distributed key generator: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to load or rebuild distributed key generator")
+	}
+
+	out, err := s.applyDealsUnderLock(codeCommitmentHex, req, dealerCount)
+	if err != nil {
+		log.Errorf("failed to persist processed deals: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to persist processed deals")
+	}
+
+	return out, nil
+}
+
+// warmGenerator get-or-builds the round's generator OUTSIDE M (a cache-miss build does
+// light-client IO for resharing). The pointer is discarded so callers re-fetch it under
+// M via a pure cache-get, seeing an eviction instead of reusing a stale pointer.
+func (s *DKGServer) warmGenerator(codeCommitmentHex string, rc *store.RoundContext, req *pb.ProcessDealsRequest) error {
+	if !req.GetIsResharing() {
+		_, err := s.GetInitDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
+		return err
+	}
+
+	_, err := s.GetResharingNextDKG(codeCommitmentHex, req.GetRound(), rc.Network.GetThreshold(), rc.SortedPubKeys)
+
+	return err
+}
+
+// applyDealsUnderLock takes M(round), cache-gets the generator, and runs applyDeals.
+// A nil result with a nil error means the round was evicted between warm and lock, so
+// the caller re-warms. M stays a leaf: only a cache-get and applyDeals run under it.
+func (s *DKGServer) applyDealsUnderLock(codeCommitmentHex string, req *pb.ProcessDealsRequest, dealerCount int) (*processedDeals, error) {
+	var out *processedDeals
+	err := s.withRoundMutation(req.GetRound(), func() error {
+		// Pure cache-get under M (no build, no IO): a miss means the round was evicted.
+		var (
+			distKeyGen *dkg.DistKeyGenerator
+			ok         bool
+		)
+		if !req.GetIsResharing() {
+			distKeyGen, ok = s.InitDKGCache.Get(req.GetRound())
+		} else {
+			distKeyGen, ok = s.ResharingNextCache.Get(req.GetRound())
+		}
+		if !ok {
+			return nil // evicted; out stays nil so the caller re-warms
+		}
+
+		resps, persisted, rejected, err := s.applyDeals(distKeyGen, codeCommitmentHex, req.GetRound(), dealerCount, req.GetDeals())
+		if err != nil {
+			return err
+		}
+		out = &processedDeals{resps: resps, persisted: persisted, rejected: rejected}
+
+		return nil
+	})
+
+	return out, err
 }
 
 // applyDeals runs each incoming deal through the cached DistKeyGenerator,

--- a/service/dkg_process_deals_test.go
+++ b/service/dkg_process_deals_test.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +16,8 @@ import (
 	"go.dedis.ch/kyber/v4"
 	"go.dedis.ch/kyber/v4/group/edwards25519"
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/piplabs/story-kernel/store"
@@ -521,4 +525,423 @@ func TestProcessDeals_ConcurrentRoundSerialized(t *testing.T) {
 	st, err := s.DKGStore.LoadDKGState(cc, round)
 	require.NoError(t, err)
 	require.Len(t, st.EmittedResponses, len(reqDeals), "no duplicate own responses")
+}
+
+// setupEvictableInitRound builds a DKGServer whose round-1 initial DKG can be
+// rebuilt from the sealed store, seeds InitDKGCache with the original generator
+// (p0), and makes the round's state directory read-only so applyDeals' persist
+// fails and triggers the #87 cache eviction while rebuild reads still succeed.
+// Shared by the #94 concurrent-resolution tests.
+func setupEvictableInitRound(t *testing.T) (s *DKGServer, cc string, round uint32, threshold, n int, pubs []kyber.Point, reqDeals []*pb.Deal, p0 *dkg.DistKeyGenerator) {
+	t.Helper()
+
+	cc = "cc-resolve-inlock"
+	round = uint32(1)
+	n = 3
+	threshold = 2
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	longterms := make([]kyber.Scalar, n)
+	pubs = make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	const self = 0
+	reqDeals = dealsAddressedTo(t, gens, self)
+
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	st := store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		stateDir,
+		suite,
+		upgradePlaintextSealer{},
+	)
+
+	// Seal self's Ed25519 key and persist threshold+pubkeys so GetInitDKG can
+	// rebuild a fresh generator after eviction.
+	selfBz, err := longterms[self].MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, round, selfBz))
+	require.NoError(t, st.SaveDKGState(&store.DKGState{Threshold: uint32(threshold), PubKeys: pubs}, cc, round))
+
+	s = &DKGServer{
+		Suite:              suite,
+		DKGStore:           st,
+		InitDKGCache:       store.NewDKGCache(),
+		ResharingNextCache: store.NewDKGCache(),
+	}
+	p0 = gens[self]
+	s.InitDKGCache.Set(round, p0)
+
+	// Read-only round dir: persist (AddProcessedDeals writes a .tmp) fails while
+	// rebuild reads succeed, forcing the eviction path. Restore on cleanup so
+	// t.TempDir removal works.
+	roundDir := filepath.Join(stateDir, fmt.Sprintf("%d", round), cc)
+	require.NoError(t, os.Chmod(roundDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(roundDir, 0o700) })
+
+	return s, cc, round, threshold, n, pubs, reqDeals, p0
+}
+
+// TestProcessDeals_ResolvesFreshGeneratorAfterEviction is the regression test for
+// issue #94. Two concurrent same-round runs mirror the fixed handler: warm the
+// generator OUTSIDE getDKGMutationMu, then take it via a pure cache-get UNDER the
+// lock, re-warming on a miss. Serialized, the winner cache-gets the seeded
+// generator and evicts it on persist failure (#87); the loser sees a cache MISS
+// under the lock, re-warms OUTSIDE the lock, and resolves a FRESH generator
+// instead of the stale pre-eviction pointer. Run with -race.
+func TestProcessDeals_ResolvesFreshGeneratorAfterEviction(t *testing.T) {
+	s, cc, round, threshold, n, pubs, reqDeals, p0 := setupEvictableInitRound(t)
+
+	// Warm outside M, cache-get + process under M, re-warm on eviction.
+	run := func() (*dkg.DistKeyGenerator, error) {
+		mu := s.getDKGMutationMu(round)
+		for attempt := 0; attempt < maxResolveDealsAttempts; attempt++ {
+			// Warm OUTSIDE the lock: a cache-miss rebuild happens here, never under M.
+			if _, err := s.GetInitDKG(cc, round, uint32(threshold), pubs); err != nil {
+				return nil, err
+			}
+
+			var (
+				gen *dkg.DistKeyGenerator
+				ok  bool
+			)
+			func() {
+				mu.Lock()
+				defer mu.Unlock()
+
+				gen, ok = s.InitDKGCache.Get(round)
+				if !ok {
+					return
+				}
+				// Persist fails under the read-only dir and evicts the cache (#87).
+				_, _, _, _ = s.applyDeals(gen, cc, round, n, reqDeals)
+			}()
+			if ok {
+				return gen, nil
+			}
+			// Evicted between warm and lock: loop re-warms OUTSIDE M.
+		}
+
+		return nil, errors.New("exhausted resolve attempts")
+	}
+
+	var (
+		wg         sync.WaitGroup
+		g1, g2     *dkg.DistKeyGenerator
+		err1, err2 error
+	)
+	wg.Add(2)
+	go func() { defer wg.Done(); g1, err1 = run() }()
+	go func() { defer wg.Done(); g2, err2 = run() }()
+	wg.Wait()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	require.NotSame(t, g1, g2, "concurrent runs must not share a stale generator pointer")
+	require.True(t, g1 == p0 || g2 == p0, "one run must resolve the seeded cached generator")
+}
+
+// TestProcessDeals_ResolveOutsideLockSharesStalePointer is the inverse-sanity
+// check for #94: with resolution OUTSIDE the lock (the pre-fix ordering) two
+// concurrent runs that both resolve before either locks share the SAME pointer,
+// which the winner then evicts — leaving the loser on a stale generator. This
+// documents the window the fix closes. Run with -race.
+func TestProcessDeals_ResolveOutsideLockSharesStalePointer(t *testing.T) {
+	s, cc, round, threshold, n, pubs, reqDeals, p0 := setupEvictableInitRound(t)
+
+	// Barrier so both runs resolve before either enters its critical section.
+	var resolved sync.WaitGroup
+	resolved.Add(2)
+
+	// Pre-fix ordering: resolve BEFORE the lock.
+	run := func() (*dkg.DistKeyGenerator, error) {
+		gen, err := s.GetInitDKG(cc, round, uint32(threshold), pubs)
+		resolved.Done()
+		if err != nil {
+			return nil, err
+		}
+		resolved.Wait()
+
+		mu := s.getDKGMutationMu(round)
+		mu.Lock()
+		defer mu.Unlock()
+		_, _, _, _ = s.applyDeals(gen, cc, round, n, reqDeals)
+
+		return gen, nil
+	}
+
+	var (
+		wg         sync.WaitGroup
+		g1, g2     *dkg.DistKeyGenerator
+		err1, err2 error
+	)
+	wg.Add(2)
+	go func() { defer wg.Done(); g1, err1 = run() }()
+	go func() { defer wg.Done(); g2, err2 = run() }()
+	wg.Wait()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	// Both resolved the seeded pointer before eviction: the shared stale window.
+	require.Same(t, p0, g1, "pre-fix ordering shares the seeded generator")
+	require.Same(t, p0, g2, "pre-fix ordering shares the seeded generator")
+}
+
+// countingResharingQC wraps the resharing build's chain queries with call
+// counters so a test can prove the in-M step issues zero queries (pure cache-get).
+type countingResharingQC struct {
+	*upgradeStubQC
+	latestCalls int32
+	regCalls    int32
+}
+
+func (q *countingResharingQC) GetLatestActiveDKGNetwork(ctx context.Context) (*pb.DKGNetwork, error) {
+	atomic.AddInt32(&q.latestCalls, 1)
+
+	return q.upgradeStubQC.GetLatestActiveDKGNetwork(ctx)
+}
+
+func (q *countingResharingQC) GetAllRegisteredDKGRegistrations(ctx context.Context, cc string, round uint32) ([]*pb.DKGRegistration, error) {
+	atomic.AddInt32(&q.regCalls, 1)
+
+	return q.upgradeStubQC.GetAllRegisteredDKGRegistrations(ctx, cc, round)
+}
+
+func (q *countingResharingQC) queries() int32 {
+	return atomic.LoadInt32(&q.latestCalls) + atomic.LoadInt32(&q.regCalls)
+}
+
+// TestProcessDeals_ResharingInLockPathIssuesNoQueries proves the #94 fix keeps
+// light-client IO OUT of the mutation lock for the resharing path: warming the
+// generator OUTSIDE M does the cache-miss build (which queries the chain), and
+// the subsequent in-M step is a pure cache-get that returns the same pointer and
+// issues zero further queries. Without warming outside M, GetResharingNextDKG's
+// unbounded network build would run while holding M — the liveness regression.
+func TestProcessDeals_ResharingInLockPathIssuesNoQueries(t *testing.T) {
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	const (
+		cc        = "cc-reshare-inlock"
+		prevRound = uint32(10)
+		toRound   = uint32(14)
+		prevT     = uint32(2)
+		nextT     = uint32(2)
+	)
+
+	point := func(seed int64) kyber.Point {
+		return suite.Point().Mul(suite.Scalar().SetInt64(seed), nil)
+	}
+
+	prevPubs := []kyber.Point{point(11), point(12), point(13)}
+	regs := make([]*pb.DKGRegistration, len(prevPubs))
+	for i, p := range prevPubs {
+		bz, err := p.MarshalBinary()
+		require.NoError(t, err)
+		regs[i] = &pb.DKGRegistration{Index: uint32(i), Round: prevRound, DkgPubKey: bz}
+	}
+
+	coeffs := []kyber.Point{point(101), point(102)} // len == prevT
+	coeffsBz, err := MarshalPoints(coeffs)
+	require.NoError(t, err)
+
+	dScalar := suite.Scalar().SetInt64(777)
+	dBz, err := dScalar.MarshalBinary()
+	require.NoError(t, err)
+	nextPubs := []kyber.Point{suite.Point().Mul(dScalar, nil), point(21), point(22)}
+
+	dir := t.TempDir()
+	st := store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		suite,
+		upgradePlaintextSealer{},
+	)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, toRound, dBz))
+
+	qc := &countingResharingQC{upgradeStubQC: &upgradeStubQC{
+		latest: &pb.DKGNetwork{Round: prevRound, Threshold: prevT, PublicCoeffs: coeffsBz},
+		regs:   regs,
+	}}
+	s := &DKGServer{
+		QueryClient:        qc,
+		Suite:              suite,
+		DKGStore:           st,
+		ResharingNextCache: store.NewDKGCache(),
+	}
+
+	mu := s.getDKGMutationMu(toRound)
+
+	// Warm OUTSIDE M: the cache-miss build queries the chain here, no lock held.
+	warmed, err := s.GetResharingNextDKG(cc, toRound, nextT, nextPubs)
+	require.NoError(t, err)
+	require.NotNil(t, warmed)
+	buildQueries := qc.queries()
+	require.Greater(t, buildQueries, int32(0), "build path must query the chain outside the lock")
+
+	// In-M step: pure cache-get, same pointer, zero additional queries.
+	mu.Lock()
+	got, ok := s.ResharingNextCache.Get(toRound)
+	mu.Unlock()
+	require.True(t, ok, "warmed resharing round must be a cache hit under M")
+	require.Same(t, warmed, got, "in-M step must return the warmed pointer, not a rebuild")
+	require.Equal(t, buildQueries, qc.queries(), "in-M cache-get must issue no chain queries")
+}
+
+// --- direct tri-state coverage for resolveAndApplyDeals / attemptDeals /
+// warmGenerator / applyDealsUnderLock (#94 decomposition) ---
+
+// setupWritableInitRound mirrors setupEvictableInitRound but leaves the round's
+// state directory writable, so AddProcessedDeals succeeds and the success path
+// through resolveAndApplyDeals can be exercised end-to-end.
+func setupWritableInitRound(t *testing.T) (s *DKGServer, cc string, round uint32, threshold, n int, pubs []kyber.Point, reqDeals []*pb.Deal, p0 *dkg.DistKeyGenerator) {
+	t.Helper()
+
+	cc = "cc-resolve-writable"
+	round = uint32(1)
+	n = 3
+	threshold = 2
+
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	longterms := make([]kyber.Scalar, n)
+	pubs = make([]kyber.Point, n)
+	for i := 0; i < n; i++ {
+		longterms[i] = suite.Scalar().Pick(suite.RandomStream())
+		pubs[i] = suite.Point().Mul(longterms[i], nil)
+	}
+
+	gens := make([]*dkg.DistKeyGenerator, n)
+	for i := 0; i < n; i++ {
+		g, err := dkg.NewDistKeyGenerator(suite, longterms[i], pubs, threshold)
+		require.NoError(t, err)
+		gens[i] = g
+	}
+
+	const self = 0
+	reqDeals = dealsAddressedTo(t, gens, self)
+
+	dir := t.TempDir()
+	st := store.NewDKGStoreWithSealer(
+		filepath.Join(dir, "keys"),
+		filepath.Join(dir, "state"),
+		suite,
+		upgradePlaintextSealer{},
+	)
+
+	selfBz, err := longterms[self].MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, st.SealAndStoreEd25519Key(cc, round, selfBz))
+	require.NoError(t, st.SaveDKGState(&store.DKGState{Threshold: uint32(threshold), PubKeys: pubs}, cc, round))
+
+	s = &DKGServer{
+		Suite:              suite,
+		DKGStore:           st,
+		InitDKGCache:       store.NewDKGCache(),
+		ResharingNextCache: store.NewDKGCache(),
+	}
+	p0 = gens[self]
+	s.InitDKGCache.Set(round, p0)
+
+	return s, cc, round, threshold, n, pubs, reqDeals, p0
+}
+
+// TestResolveAndApplyDeals_Success drives resolveAndApplyDeals directly on a
+// writable round: warmGenerator cache-hits the seeded generator, applyDealsUnderLock
+// takes M, cache-gets it, and applyDeals persists successfully on the first
+// attempt. Covers the success leg of the tri-state across all four #94 functions.
+func TestResolveAndApplyDeals_Success(t *testing.T) {
+	t.Parallel()
+
+	s, cc, round, threshold, n, pubs, reqDeals, _ := setupWritableInitRound(t)
+
+	rc := &store.RoundContext{
+		Round:         round,
+		Network:       &pb.DKGNetwork{Threshold: uint32(threshold)},
+		SortedPubKeys: pubs,
+	}
+	req := &pb.ProcessDealsRequest{
+		Round:          round,
+		CodeCommitment: []byte(cc),
+		Deals:          reqDeals,
+		IsResharing:    false,
+	}
+
+	out, err := s.resolveAndApplyDeals(cc, rc, req, n)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotEmpty(t, out.resps, "success must emit at least one response")
+
+	st, err := s.DKGStore.LoadDKGState(cc, round)
+	require.NoError(t, err)
+	require.Len(t, st.Deals, len(reqDeals), "deals must be persisted on the success path")
+}
+
+// TestApplyDealsUnderLock_CacheMissSignalsEviction covers the !ok branch of
+// applyDealsUnderLock directly: with the round absent from both caches, the
+// pure cache-get under M misses and the function must return (nil, nil) — the
+// eviction signal resolveAndApplyDeals retries on — not an error.
+func TestApplyDealsUnderLock_CacheMissSignalsEviction(t *testing.T) {
+	t.Parallel()
+
+	s := &DKGServer{
+		InitDKGCache:       store.NewDKGCache(),
+		ResharingNextCache: store.NewDKGCache(),
+	}
+	req := &pb.ProcessDealsRequest{
+		Round:          1,
+		CodeCommitment: []byte("cc-evicted"),
+		Deals:          []*pb.Deal{{Index: 0}},
+		IsResharing:    false,
+	}
+
+	out, err := s.applyDealsUnderLock("cc-evicted", req, 3)
+	require.NoError(t, err)
+	require.Nil(t, out, "cache miss must signal eviction with a nil result and nil error")
+}
+
+// TestResolveAndApplyDeals_PersistFailureIsInternalNotEviction is the regression
+// guard for the hard-error leg of the tri-state: on the seeded read-only round,
+// warmGenerator cache-hits (no rebuild needed) and applyDeals fails to persist.
+// That must surface as codes.Internal — never be misread as the (nil, nil)
+// eviction signal, which would silently retry and mask the persist failure.
+func TestResolveAndApplyDeals_PersistFailureIsInternalNotEviction(t *testing.T) {
+	s, cc, round, threshold, n, pubs, reqDeals, _ := setupEvictableInitRound(t)
+
+	rc := &store.RoundContext{
+		Round:         round,
+		Network:       &pb.DKGNetwork{Threshold: uint32(threshold)},
+		SortedPubKeys: pubs,
+	}
+	req := &pb.ProcessDealsRequest{
+		Round:          round,
+		CodeCommitment: []byte(cc),
+		Deals:          reqDeals,
+		IsResharing:    false,
+	}
+
+	out, err := s.resolveAndApplyDeals(cc, rc, req, n)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.Equal(t, codes.Internal, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "failed to persist processed deals")
+
+	// NOTE on exhaustion (codes.Unavailable): forcing every attempt to observe an
+	// eviction requires either a production test seam or a real concurrent evictor
+	// racing every retry, both of which are ruled out by the task constraints. The
+	// Unavailable terminal is covered behaviorally by
+	// TestProcessDeals_ResolvesFreshGeneratorAfterEviction and
+	// TestProcessDeals_ResolveOutsideLockSharesStalePointer above, which exercise
+	// the same warm/lock/re-warm cycle under real concurrency.
 }

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -123,91 +123,92 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
 	// RPCs for this round (see dkgMutationMu). Persist runs after the loop under
 	// its own store lock, so only the kyber mutation needs covering here.
-	mu := s.getDKGMutationMu(req.GetRound())
-	mu.Lock()
-	for _, j := range req.GetJustifications() {
-		justification, err := types.ConvertToJustification(j)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"round":           req.GetRound(),
-				"code_commitment": codeCommitmentHex,
-			}).Errorf("failed to convert justification from proto: %v", err)
+	_ = s.withRoundMutation(req.GetRound(), func() error {
+		for _, j := range req.GetJustifications() {
+			justification, err := types.ConvertToJustification(j)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"round":           req.GetRound(),
+					"code_commitment": codeCommitmentHex,
+				}).Errorf("failed to convert justification from proto: %v", err)
 
-			rejected = append(rejected, j)
+				rejected = append(rejected, j)
 
-			continue
-		}
+				continue
+			}
 
-		// Defence in depth: bounds-check both the dealer and the recipient
-		// index before kyber. In resharing the dealer is an old-committee
-		// member (range [0, dealerCount)) and the recipient is a new-committee
-		// member (range [0, recipientCount)).
-		if int(justification.Index) >= dealerCount ||
-			int(j.GetVssJustification().GetIndex()) >= recipientCount {
-			rejected = append(rejected, j)
+			// Defence in depth: bounds-check both the dealer and the recipient
+			// index before kyber. In resharing the dealer is an old-committee
+			// member (range [0, dealerCount)) and the recipient is a new-committee
+			// member (range [0, recipientCount)).
+			if int(justification.Index) >= dealerCount ||
+				int(j.GetVssJustification().GetIndex()) >= recipientCount {
+				rejected = append(rejected, j)
 
-			continue
-		}
+				continue
+			}
 
-		// applied:          at least one DistKeyGenerator successfully
-		//                   absorbed this justification on THIS call. Only
-		//                   then is it safe to persist for replay.
-		// alreadyProcessed: at least one DistKeyGenerator reported the
-		//                   justification was absorbed on a PRIOR call
-		//                   (idempotent re-submission). Silently skip — do
-		//                   not reject, do not persist. Persisting a
-		//                   duplicate would cause replayMessages (which
-		//                   does NOT suppress duplicate justification
-		//                   errors, unlike responses) to fail fatally on
-		//                   restart.
-		// Reject only when EVERY generator returned a real (non-idempotent)
-		// error.
-		applied := false
-		alreadyProcessed := false
-		for _, distKeyGen := range distKeyGens {
-			if err := distKeyGen.ProcessJustification(justification); err != nil {
+			// applied:          at least one DistKeyGenerator successfully
+			//                   absorbed this justification on THIS call. Only
+			//                   then is it safe to persist for replay.
+			// alreadyProcessed: at least one DistKeyGenerator reported the
+			//                   justification was absorbed on a PRIOR call
+			//                   (idempotent re-submission). Silently skip — do
+			//                   not reject, do not persist. Persisting a
+			//                   duplicate would cause replayMessages (which
+			//                   does NOT suppress duplicate justification
+			//                   errors, unlike responses) to fail fatally on
+			//                   restart.
+			// Reject only when EVERY generator returned a real (non-idempotent)
+			// error.
+			applied := false
+			alreadyProcessed := false
+			for _, distKeyGen := range distKeyGens {
+				if err := distKeyGen.ProcessJustification(justification); err != nil {
+					log.WithFields(log.Fields{
+						"round":           req.GetRound(),
+						"code_commitment": codeCommitmentHex,
+						"dealer_index":    justification.Index,
+					}).Errorf("failed to process justification: %v", err)
+
+					if isAlreadyProcessedErr(err) {
+						alreadyProcessed = true
+					}
+
+					continue
+				}
+				applied = true
+			}
+
+			if !applied && !alreadyProcessed {
+				rejected = append(rejected, j)
+
+				continue
+			}
+
+			if !applied {
+				// Idempotent re-submission only — do not persist. Logging at
+				// debug to mirror the dealing handler's silent-skip semantics.
 				log.WithFields(log.Fields{
 					"round":           req.GetRound(),
 					"code_commitment": codeCommitmentHex,
 					"dealer_index":    justification.Index,
-				}).Errorf("failed to process justification: %v", err)
-
-				if isAlreadyProcessedErr(err) {
-					alreadyProcessed = true
-				}
+				}).Debug("justification already stored on cached generator; skipping silently")
 
 				continue
 			}
-			applied = true
-		}
 
-		if !applied && !alreadyProcessed {
-			rejected = append(rejected, j)
+			justs = append(justs, *justification)
 
-			continue
-		}
-
-		if !applied {
-			// Idempotent re-submission only — do not persist. Logging at
-			// debug to mirror the dealing handler's silent-skip semantics.
 			log.WithFields(log.Fields{
 				"round":           req.GetRound(),
 				"code_commitment": codeCommitmentHex,
 				"dealer_index":    justification.Index,
-			}).Debug("justification already stored on cached generator; skipping silently")
-
-			continue
+			}).Info("Justification processed successfully, DKG state restored for the deal")
 		}
 
-		justs = append(justs, *justification)
-
-		log.WithFields(log.Fields{
-			"round":           req.GetRound(),
-			"code_commitment": codeCommitmentHex,
-			"dealer_index":    justification.Index,
-		}).Info("Justification processed successfully, DKG state restored for the deal")
-	}
-	mu.Unlock()
+		return nil
+	})
 
 	// Persist successfully processed justifications for recovery replay
 	if len(justs) > 0 {

--- a/service/dkg_process_justification.go
+++ b/service/dkg_process_justification.go
@@ -122,7 +122,8 @@ func (s *DKGServer) ProcessJustification(_ context.Context, req *pb.ProcessJusti
 
 	// Serialize the shared DistKeyGenerator mutation with the other DKG-mutating
 	// RPCs for this round (see dkgMutationMu). Persist runs after the loop under
-	// its own store lock, so only the kyber mutation needs covering here.
+	// its own store lock, so only the kyber mutation needs covering here. The
+	// closure collects rejects rather than erroring, so it never returns non-nil.
 	_ = s.withRoundMutation(req.GetRound(), func() error {
 		for _, j := range req.GetJustifications() {
 			justification, err := types.ConvertToJustification(j)

--- a/service/dkg_process_responses.go
+++ b/service/dkg_process_responses.go
@@ -133,14 +133,20 @@ func (s *DKGServer) ProcessResponses(_ context.Context, req *pb.ProcessResponses
 	// RPCs for this round (see dkgMutationMu). Held across process+persist so a
 	// retry sees a fully persisted state and re-emits its emitted justifications
 	// deterministically. Lock order dkgMutationMu -> stateMu stays one-directional.
-	mu := s.getDKGMutationMu(req.GetRound())
-	mu.Lock()
-	justifications, processed, rejected, err := s.applyResponses(
-		distKeyGens, req.GetIsResharing(), codeCommitmentHex, req.GetRound(),
-		latestActiveRound, dealerCount, complainerCount, req.GetResponses(),
+	var (
+		justifications []*pb.Justification
+		processed      int
+		rejected       []*pb.Response
 	)
-	mu.Unlock()
-	if err != nil {
+	if err := s.withRoundMutation(req.GetRound(), func() error {
+		var err error
+		justifications, processed, rejected, err = s.applyResponses(
+			distKeyGens, req.GetIsResharing(), codeCommitmentHex, req.GetRound(),
+			latestActiveRound, dealerCount, complainerCount, req.GetResponses(),
+		)
+
+		return err
+	}); err != nil {
 		log.Errorf("failed to add processed responses to the DKG state: %v", err)
 
 		return nil, status.Errorf(codes.Internal, "failed to add processed responses to the DKG state")

--- a/service/dkg_server.go
+++ b/service/dkg_server.go
@@ -56,6 +56,18 @@ func (s *DKGServer) getDKGMutationMu(round uint32) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
+// withRoundMutation runs fn while holding the round's DKG mutation lock M(round), which
+// serializes every DKG-mutating RPC for the round. M is a LEAF lock: fn must not build a
+// generator, do light-client IO, or acquire another round's M. Unlock is deferred so a
+// panic in fn cannot poison the lock.
+func (s *DKGServer) withRoundMutation(round uint32, fn func() error) error {
+	mu := s.getDKGMutationMu(round)
+	mu.Lock()
+	defer mu.Unlock()
+
+	return fn()
+}
+
 func (s *DKGServer) getReshareNextMu(round uint32) *sync.Mutex {
 	v, _ := s.reshareNextMu.LoadOrStore(round, &sync.Mutex{})
 	return v.(*sync.Mutex)


### PR DESCRIPTION
## Problem
`getDKGMutationMu(round)` (M) was taken at scattered sites with manual `Lock`/`Unlock` and ad-hoc closures across the six DKG-mutating critical sections — easy to misuse or forget to release. Separately, `ProcessDeals` resolved the cached `*dkg.DistKeyGenerator` before taking M, so a timed-out handler and its retry could capture the same pointer; when the winner evicted it on a persist failure (#87), the loser processed a stale, evicted instance.

## Fix
- Add `withRoundMutation(round, fn)` and route all six mutating critical sections (`ProcessDeals`/`ProcessResponses`/`ProcessJustification`/`FinalizeDKG`/`GenerateDeals` and the resharing from-round share read) through it, so Unlock cannot leak on an early return or panic. M stays a leaf lock.
- `ProcessDeals` warms the generator OUTSIDE M (a cache-miss build does light-client IO), then under M takes it via a pure cache-get and processes; on an eviction between warm and lock it re-warms outside M and retries, bounded by `maxResolveDealsAttempts`, so the loser resolves a fresh generator. Returns `Unavailable` if exhausted.

## Test coverage
`go test -race ./service/...`

| Symbol | Coverage |
|---|---|
| `withRoundMutation` | 100% |
| `applyDealsUnderLock` | 92.9% |
| `resolveAndApplyDeals`, `attemptDeals` | 75% |
| `warmGenerator` | 60% (non-resharing path directly tested) |

issue: #94
