### PR TITLE
fix(service): generate and seal keys only after the round is verified on-chain

### DIFF
--- a/service/dkg_generate_key.go
+++ b/service/dkg_generate_key.go
@@ -36,29 +36,6 @@ func (s *DKGServer) GenerateAndSealKey(_ context.Context, req *pb.GenerateAndSea
 		return nil, status.Errorf(codes.InvalidArgument, "failed to validate code commitment")
 	}
 
-	_, edPub, err := s.DKGStore.LoadOrGenerateEd25519Key(codeCommitmentHex, req.GetRound())
-	if err != nil {
-		log.Errorf("failed to load or generate Ed25519 key: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to load or generate Ed25519 key")
-	}
-
-	edPubBz, err := edPub.MarshalBinary()
-	if err != nil {
-		log.Errorf("failed to marshal the Ed25519 public key: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to marshal the Ed25519 public key")
-	}
-
-	_, secpPub, err := s.DKGStore.LoadOrGenerateSecp256k1Key(codeCommitmentHex, req.GetRound())
-	if err != nil {
-		log.Errorf("failed to load or generate Secp256k1 key: %v", err)
-
-		return nil, status.Errorf(codes.Internal, "failed to load or generate Secp256k1 key")
-	}
-
-	log.Info("Key pairs are successfully generated and sealed or loaded from the existing key files")
-
 	// Only fetch the DKG network (not registrations) since no registrations
 	// exist yet at key generation time.
 	network, err := s.QueryClient.GetDKGNetwork(context.Background(), codeCommitmentHex, req.Round)
@@ -86,6 +63,31 @@ func (s *DKGServer) GenerateAndSealKey(_ context.Context, req *pb.GenerateAndSea
 			"start block verification failed at height %d: %v",
 			network.StartBlockHeight, err)
 	}
+
+	// Generate (or load) the key pairs only after the round is proven to exist on the
+	// canonical chain, so requests for bogus rounds cannot mint sealed key files.
+	_, edPub, err := s.DKGStore.LoadOrGenerateEd25519Key(codeCommitmentHex, req.GetRound())
+	if err != nil {
+		log.Errorf("failed to load or generate Ed25519 key: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to load or generate Ed25519 key")
+	}
+
+	edPubBz, err := edPub.MarshalBinary()
+	if err != nil {
+		log.Errorf("failed to marshal the Ed25519 public key: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to marshal the Ed25519 public key")
+	}
+
+	_, secpPub, err := s.DKGStore.LoadOrGenerateSecp256k1Key(codeCommitmentHex, req.GetRound())
+	if err != nil {
+		log.Errorf("failed to load or generate Secp256k1 key: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to load or generate Secp256k1 key")
+	}
+
+	log.Info("Key pairs are successfully generated and sealed or loaded from the existing key files")
 
 	reportData, err := calculateReportData(
 		req.Address,


### PR DESCRIPTION
## Problem
`GenerateAndSealKey` mints sealed key files before checking that the requested round exists, so requests carrying arbitrary round numbers create key files on disk without bound.

## Fix
Fetch the round's `DKGNetwork` and run `verifyDKGStartBlock` before `LoadOrGenerate{Ed25519,Secp256k1}Key`. Key material, report data, and quote contents are unchanged, and the load-or-generate path stays idempotent, so retried calls converge on the same sealed keys.

## Context
Best merged together with #97: alone on `main`, the (unchanged) no-retry network read fails before key generation during a round-boundary light-client lag — functionally fine (the per-block session resume converges) but with avoidable `MarkFailed` churn.

## Tests
No new tests — no behavior change for legitimate flows; existing `service` suite passes.

issue: none