### PR TITLE
harden(server): cap concurrent gRPC streams per connection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,11 +31,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// maxConcurrentStreams bounds concurrent RPCs per client connection. The kernel serves a
+// single co-located consensus client, so legitimate load stays far below this; the cap
+// keeps a misbehaving peer from parking unbounded long-lived handlers (e.g. registration
+// lag-retry waits).
+const maxConcurrentStreams = 64
+
 func Serve(cfg *config.Config) (*grpc.Server, chan error) {
 	errCh := make(chan error)
 
 	serverOpts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(recoveryInterceptor()),
+		grpc.MaxConcurrentStreams(maxConcurrentStreams),
 	}
 
 	if cfg.GRPC.TLSEnabled() {


### PR DESCRIPTION
## Problem
The kernel gRPC server sets no stream limit, so a single peer connection can park an unbounded number of concurrent long-lived handlers.

## Fix
Set `grpc.MaxConcurrentStreams(64)`. Legitimate load is a single co-located consensus client whose peak is ~10 parallel partial-decrypt streams plus a handful of lifecycle RPCs, far below the cap.

## Tests
No new tests — declarative server option; existing suite passes.

issue: none