### PR TITLE
fix(store): serialize key load-or-generate to close the exists-check race

### DIFF
--- a/store/dkg_store.go
+++ b/store/dkg_store.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 
 	"github.com/piplabs/story-kernel/config"
 	"github.com/piplabs/story-kernel/enclave"
@@ -50,6 +51,13 @@ type DKGStore struct {
 
 	keyDir   string
 	stateDir string
+
+	// keyMu serializes LoadOrGenerate* key calls so two concurrent requests for the same
+	// round cannot both miss the file-exists check and generate different keys, where the
+	// loser's sealed file would silently replace the key the winner already returned.
+	// Store-wide by design: key generation happens once per round at registration, so
+	// cross-round contention is negligible and per-round granularity is not worth it.
+	keyMu sync.Mutex
 }
 
 // NewDKGStore creates a DKGStore that uses the real SGX enclave sealer.

--- a/store/key_store.go
+++ b/store/key_store.go
@@ -25,6 +25,9 @@ func (s *DKGStore) secp256k1Path(codeCommitmentHex string, round uint32) string 
 }
 
 func (s *DKGStore) LoadOrGenerateEd25519Key(codeCommitmentHex string, round uint32) (kyber.Scalar, kyber.Point, error) {
+	s.keyMu.Lock()
+	defer s.keyMu.Unlock()
+
 	var (
 		edPriv kyber.Scalar
 		edPub  kyber.Point
@@ -80,6 +83,9 @@ func (s *DKGStore) LoadSealedEd25519Key(codeCommitmentHex string, round uint32) 
 }
 
 func (s *DKGStore) LoadOrGenerateSecp256k1Key(codeCommitmentHex string, round uint32) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
+	s.keyMu.Lock()
+	defer s.keyMu.Unlock()
+
 	var (
 		secpPriv *ecdsa.PrivateKey
 		secpPub  *ecdsa.PublicKey

--- a/store/key_store_test.go
+++ b/store/key_store_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
+	"go.dedis.ch/kyber/v4"
 	"go.dedis.ch/kyber/v4/group/edwards25519"
 )
 
@@ -457,4 +459,57 @@ func TestLoadSealedSecp256k1Key_WrongCurveKey(t *testing.T) {
 	// The call may or may not error depending on whether the P-256 scalar
 	// is also a valid secp256k1 scalar. We only check it doesn't panic.
 	_ = err
+}
+
+// TestLoadOrGenerateKeys_ConcurrentSameRound verifies concurrent LoadOrGenerate calls for
+// the same (code commitment, round) cannot race the exists-check and mint different keys:
+// every caller must observe the same key pair as a sequential re-load.
+func TestLoadOrGenerateKeys_ConcurrentSameRound(t *testing.T) {
+	t.Parallel()
+	store := newTestDKGStoreWithSealer(t)
+	cc := "concurrent"
+	round := uint32(7)
+
+	const callers = 8
+	edPubs := make([]kyber.Point, callers)
+	secpPubs := make([]*ecdsa.PublicKey, callers)
+	// Collect errors per goroutine; require/FailNow must only run on the test goroutine.
+	errs := make([]error, callers)
+
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, edPub, err := store.LoadOrGenerateEd25519Key(cc, round)
+			if err != nil {
+				errs[i] = err
+
+				return
+			}
+			_, secpPub, err := store.LoadOrGenerateSecp256k1Key(cc, round)
+			if err != nil {
+				errs[i] = err
+
+				return
+			}
+			edPubs[i] = edPub
+			secpPubs[i] = secpPub
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "caller %d", i)
+	}
+
+	// All callers agree with each other and with the sealed files on disk.
+	_, edPubReload, err := store.LoadOrGenerateEd25519Key(cc, round)
+	require.NoError(t, err)
+	_, secpPubReload, err := store.LoadOrGenerateSecp256k1Key(cc, round)
+	require.NoError(t, err)
+	for i := range callers {
+		require.True(t, edPubs[i].Equal(edPubReload), "caller %d observed a different Ed25519 key", i)
+		require.True(t, secpPubs[i].Equal(secpPubReload), "caller %d observed a different Secp256k1 key", i)
+	}
 }


### PR DESCRIPTION
## Problem
Two concurrent `LoadOrGenerate{Ed25519,Secp256k1}Key` calls for the same `(round, code commitment)` can both miss the file-exists check and generate different key pairs; the loser's sealed file silently replaces the key the winner already returned.

## Fix
Guard both load-or-generate paths with a store-level mutex (`keyMu`). The lock is a leaf held only across the sealer file IO; the plain `LoadSealed*` read paths are untouched.

## Tests
- `TestLoadOrGenerateKeys_ConcurrentSameRound` — 8 concurrent callers must observe the same key pair; passes under `-race`.

issue: none